### PR TITLE
Set height for display for visual samples so they aren't vertically truncated.

### DIFF
--- a/components/table/README.md
+++ b/components/table/README.md
@@ -16,7 +16,7 @@ Tables present tabular data in a grid which allows users to visually scan and un
 
 ## Visual Example
 
-<component-preview path="components/table/sample.html"> </component-preview>
+<component-preview path="components/table/sample.html" height="250px"> </component-preview>
 
 ## How to Use This
 


### PR DESCRIPTION
This will close #104.

@orinevares I've added an example of what needs to be done for each of the components that aren't dispalying properly - basically going through and figuring out a suitable value in pixels for the height that causes the whole component to show, no scrollbars, and a reasonable amount of white space.  let me know if you need help determining this.  Otherwise, you can work through each one, push to this PR and things will start to look much better.