### PR TITLE
Text input - textarea - typography update

### DIFF
--- a/components/text_input/README.md
+++ b/components/text_input/README.md
@@ -67,13 +67,9 @@ As read using ChromeVox
 
     <form>
       <div class="text_label">
-        <label>First Name:</label>
+        <label>Input label</label>
       </div>
-      <input class="text_input" type="text" name="firstname"><br>
-      <div class="text_label">
-        <label> Last Name:</label>
-      </div>
-      <input class="text_input" type="text" name="lastname">
+      <input class="text_input" type="text" name="labelname"><br>
     </form>
 
   </body>
@@ -92,12 +88,12 @@ form {
 }
 
 .text_input {
-  height: 25px;
+  height: 34px;
   border: 2px solid #38598a;
   margin-top: 5px;
   margin-bottom: 15px;
-  border-radius: 3px;
-  padding: 5px;
+  border-radius: 4px;
+  padding: 5px 5px 5px 7px;
 }
 
 .text_input[type="text"]:focus {
@@ -109,5 +105,3 @@ form {
   display: flex;
 }
 ```
-### Assets
-	Assets go here

--- a/components/text_input/index.html
+++ b/components/text_input/index.html
@@ -10,13 +10,9 @@
 
     <form>
       <div class="text_label">
-        <label>First Name:</label>
+        <label>First name</label>
       </div>
       <input class="text_input" type="text" name="firstname"><br>
-      <div class="text_label">
-        <label> Last Name:</label>
-      </div>
-      <input class="text_input" type="text" name="lastname">
     </form>
 
   </body>

--- a/components/text_input/sample.html
+++ b/components/text_input/sample.html
@@ -17,12 +17,12 @@
       }
 
       .text_input {
-        height: 25px;
+        height: 34px;
         border: 2px solid #38598a;
         margin-top: 5px;
         margin-bottom: 15px;
         border-radius: 4px;
-        padding: 5px;
+        padding: 5px 5px 5px 7px;
       }
 
       .text_input[type="text"]:focus {
@@ -39,13 +39,9 @@
 
     <form>
       <div class="text_label">
-        <label>First Name:</label>
+        <label>First name</label>
       </div>
       <input class="text_input" type="text" name="firstname"><br>
-      <div class="text_label">
-        <label> Last Name:</label>
-      </div>
-      <input class="text_input" type="text" name="lastname">
     </form>
 
   </body>

--- a/components/text_input/style.css
+++ b/components/text_input/style.css
@@ -9,12 +9,12 @@ form {
 }
 
 .text_input {
-  height: 25px;
+  height: 34px;
   border: 2px solid #38598a;
   margin-top: 5px;
   margin-bottom: 15px;
   border-radius: 4px;
-  padding: 5px;
+  padding: 5px 5px 5px 7px;
 }
 
 .text_input[type="text"]:focus {

--- a/components/textarea/README.md
+++ b/components/textarea/README.md
@@ -69,7 +69,7 @@ As read using ChromeVox
       <div class="text_label">
         <label>Can you provide more detail?</label>
       </div>
-      <textarea class="text_input" name="name" rows="8" cols="80"></textarea>
+      <textarea class="text_input" name="name" rows="8" cols="60"></textarea>
     </form>
 
   </body>
@@ -79,16 +79,16 @@ As read using ChromeVox
 ```css
 form {
   font-family: 'Noto Sans','Calibri', 'Arial', 'Sans Serif';
-  font-size: 16px;
+  font-size: 18px;
 }
 
 .text_input {
   font-family: 'Noto Sans','Calibri', 'Arial', 'Sans Serif';
-  font-size: 16px;
+  font-size: 18px;
   border: 2px solid #38598a;
   margin-top: 5px;
   margin-bottom: 15px;
-  border-radius: 3px;
+  border-radius: 4;
   padding: 5px;
   resize: none;
 }

--- a/components/textarea/index.html
+++ b/components/textarea/index.html
@@ -12,7 +12,7 @@
       <div class="text_label">
         <label>Can you provide more detail?</label>
       </div>
-      <textarea class="text_input" name="name" rows="8" cols="80"></textarea>
+      <textarea class="text_input" name="name" rows="8" cols="60"></textarea>
     </form>
 
   </body>

--- a/components/textarea/sample.html
+++ b/components/textarea/sample.html
@@ -38,7 +38,7 @@
       <div class="text_label">
         <label>Can you provide more detail?</label>
       </div>
-      <textarea class="text_input" name="name" rows="8" cols="80"></textarea>
+      <textarea class="text_input" name="name" rows="8" cols="60"></textarea>
     </form>
 
   </body>

--- a/styles/typography/header-sample.html
+++ b/styles/typography/header-sample.html
@@ -7,7 +7,7 @@
     <title>Headings</title>
     <style>
     body {
-    font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
+    font-family: "Noto Sans", Verdana, Arial, sans-serif;
     font-weight: 400;
     }
 

--- a/styles/typography/paragraph-sample.html
+++ b/styles/typography/paragraph-sample.html
@@ -7,7 +7,7 @@
     <title>Headings</title>
     <style>
     body {
-      font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
+      font-family: "Noto Sans", Verdana, Arial, sans-serif;
       font-weight: 400;
     }
 
@@ -21,7 +21,7 @@
   </head>
   <body>
 
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <p>Members of the public service are the politically impartial government employees who are responsible for carrying out the day-to-day activities of government and for delivering public services to the citizens of B.C.</p>
 
   </body>
 </html>


### PR DESCRIPTION
Things changed:

Text input:

- label changed to remove colon, and use sentence case as per the guidance
- increased text input size so it's 44px min

Text area:
- Shortened the width because it was extended past the iframe

typography page:
- Noto isn't rendering in the iframe example, I think the quotes were causing issues
- replaced filler lorem ipsum text for real text