### PR TITLE
Added ‘BCSans’ as font-fam property in all component readme

### DIFF
--- a/components/abbreviations/README.md
+++ b/components/abbreviations/README.md
@@ -45,7 +45,7 @@ This component has been built according to [WCAG 2.0 AAA](https://www.w3.org/TR/
 ```css
 
 p {
-  font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
   font-size: 18px;
   line-height: 1.6;
   color: #494949;

--- a/components/alert_banners/README.md
+++ b/components/alert_banners/README.md
@@ -113,7 +113,7 @@ As read using ChromeVox
 ```css
 
 body {
-  font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
   font-size: 18px;
   line-height: 1.6;
   color: #494949;

--- a/components/beta/README.md
+++ b/components/beta/README.md
@@ -84,7 +84,7 @@ header {
 }
 
 header h1 {
-  font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
   font-weight: normal;  /* 400 */
   margin: 5px 5px 0 18px;
   visibility: hidden;

--- a/components/checkbox/README.md
+++ b/components/checkbox/README.md
@@ -89,7 +89,7 @@ As read using ChromeVox
   padding-left: 25px;
   margin-bottom: 12px;
   cursor: pointer;
-  Font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
+  Font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
   font-size: 16px;
   -webkit-user-select: none;
   -moz-user-select: none;

--- a/components/date_input/README.md
+++ b/components/date_input/README.md
@@ -84,7 +84,7 @@ As read using ChromeVox
 
 ```css
 form {
-    font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
+    font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
     font-size: 16px;
     display: flex;
 }

--- a/components/disabled_button/README.md
+++ b/components/disabled_button/README.md
@@ -59,7 +59,7 @@ This supports WCAG 2.0 1.4.1 Use of Color: Color is not used as the only visual 
     text-decoration: none;
     display: block;
     font-size: 18px;
-    font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
+    font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
     font-weight: 700;
     letter-spacing: 1px;
     cursor: not-allowed;

--- a/components/dropdown/README.md
+++ b/components/dropdown/README.md
@@ -65,7 +65,7 @@ As read using ChromeVox
 ### CSS
 ```css
 body {
-  font-family: "Noto Sans", Verdana, Arial, sans-serif;
+  font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
   font-size: 18px;
 }
 
@@ -80,7 +80,7 @@ body {
 }
 
 .bc-gov-dropdown {
-  font-family: "Noto Sans", Verdana, Arial, sans-serif;
+  font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
   font-size: 18px;
   color: #494949;
   background: white;

--- a/components/footer/README.md
+++ b/components/footer/README.md
@@ -79,7 +79,7 @@ footer {
   background-color: #036;
   border-top: 2px solid #fcba19;
   color: #fff;
-  font-family: ‘Noto Sans’, Verdana, Arial, sans-serif; 
+  font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif; 
 }
 
 footer .container {

--- a/components/header/README.md
+++ b/components/header/README.md
@@ -111,7 +111,7 @@ header {
 }
 
 header h1 {
-  font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
   font-weight: normal;  /* 400 */
   margin: 5px 5px 0 18px;
   visibility: hidden;

--- a/components/link/README.md
+++ b/components/link/README.md
@@ -69,7 +69,7 @@ As read using ChromeVox
 
 ```css
 body {
-  font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
   font-size: 18px;
 }
 

--- a/components/navbar/README.md
+++ b/components/navbar/README.md
@@ -156,7 +156,7 @@ header {
   }
   
   header h1 {
-    font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
+    font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
     font-weight: normal;  /* 400 */
     margin: 5px 5px 0 18px;
     visibility: hidden;

--- a/components/radio/README.md
+++ b/components/radio/README.md
@@ -96,7 +96,7 @@ If a radio button was selected
   margin-bottom: 12px;
   cursor: pointer;
   font-size: 18px;
-  font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;

--- a/components/secondary_button/README.md
+++ b/components/secondary_button/README.md
@@ -68,7 +68,7 @@ As read using ChromeVox
     text-decoration: none;
     display: block;
     font-size: 18px;
-    Font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
+    Font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
     font-weight: 700;
     letter-spacing: 1px;
     cursor: pointer;

--- a/components/table/README.md
+++ b/components/table/README.md
@@ -67,7 +67,7 @@ This component has been built according to [WCAG 2.0 AA](https://www.w3.org/TR/W
 ```css
 body {
   font-size: 16px;
-  font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
 }
 
 table, th, td {

--- a/components/text_input/README.md
+++ b/components/text_input/README.md
@@ -65,12 +65,12 @@ As read using ChromeVox
 ### CSS
 ```css
 form {
-  font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
   font-size: 18px;
 }
 
 .text_input {
-  font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
   font-size: 18px;
 }
 

--- a/components/textarea/README.md
+++ b/components/textarea/README.md
@@ -65,12 +65,12 @@ As read using ChromeVox
 ### CSS
 ```css
 form {
-  font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
   font-size: 18px;
 }
 
 .text_input {
-  font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
+  font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
   font-size: 18px;
   border: 2px solid #606060;
   margin-top: 5px;

--- a/styles/typography/header-sample.html
+++ b/styles/typography/header-sample.html
@@ -7,7 +7,7 @@
     <title>Headings</title>
     <style>
     body {
-    font-family: "Noto Sans", Verdana, Arial, sans-serif;
+    font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
     font-weight: 400;
     }
 

--- a/styles/typography/paragraph-sample.html
+++ b/styles/typography/paragraph-sample.html
@@ -7,7 +7,7 @@
     <title>Headings</title>
     <style>
     body {
-      font-family: "Noto Sans", Verdana, Arial, sans-serif;
+      font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
       font-weight: 400;
     }
 


### PR DESCRIPTION
 ‘BCSans’  was added as a font-family property in all component readme files. For consistency, one instance of Noto Sans was wrapped in single quotes, instead of double.