### PR TITLE
Update Colour Palette text color

### DIFF
--- a/components/abbreviations/README.md
+++ b/components/abbreviations/README.md
@@ -7,7 +7,7 @@ author: orinevares
 
 ![Status](https://img.shields.io/badge/Recommended-Draft-orange.svg)
 
-> Last Updated: June 5, 2019
+> Last Updated: April 30, 2020
 
 # Abbreviations and Acronyms
 An abbreviation or acronym is a shortened form of a word, phrase, or name. They are often used to reduce redundancy within a body of text.
@@ -48,7 +48,7 @@ p {
   font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
   font-size: 18px;
   line-height: 1.6;
-  color: #494949;
+  color: #313132;
 }
 
 ```

--- a/components/abbreviations/sample.html
+++ b/components/abbreviations/sample.html
@@ -11,7 +11,7 @@
         font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
         font-size: 18px;
         line-height: 1.6;
-        color: #494949;
+        color: #313132;
       }
   </style>
   <body>

--- a/components/abbreviations/style.css
+++ b/components/abbreviations/style.css
@@ -2,5 +2,5 @@ p {
   font-family: ‘Noto Sans’, Verdana, Arial, sans-serif;
   font-size: 18px;
   line-height: 1.6;
-  color: #494949;
+  color: #313132;
 }

--- a/components/callout/sample.html
+++ b/components/callout/sample.html
@@ -10,13 +10,13 @@
             font-weight: 400;
             line-height: 1.6;
             font-size: 18px;
-            color: #494949;
+            color: #313132;
             padding: 25px;
             border-left: 10px solid #38598a;
             margin: 16px 0;
             background-color: #f2f2f2;
           }
-  
+
          .bcgov-callout, h1, h2, h3, h4 {
             margin: 0;
           }

--- a/components/callout/style.css
+++ b/components/callout/style.css
@@ -3,13 +3,13 @@
     font-weight: 400;
     line-height: 1.6;
     font-size: 18px;
-    color: #494949;
+    color: #313132;
     padding: 25px;
     border-left: 10px solid #38598a;
     margin: 16px 0;
     background-color: #f2f2f2;
   }
-  
+
   .bcgov-callout, h1, h2, h3, h4 {
     margin: 0;
   }

--- a/components/dropdown/README.md
+++ b/components/dropdown/README.md
@@ -6,7 +6,7 @@ author: orinevares
 ---
 
 ![Status](https://img.shields.io/badge/Recommended-Draft-orange.svg)
-> Last Updated: April 3, 2019
+> Last Updated: April 30, 2020
 
 # Dropdown
 Dropdowns allow users to select one option from a list.
@@ -82,7 +82,7 @@ body {
 .bc-gov-dropdown {
   font-family: ‘BCSans’, ‘Noto Sans’, Verdana, Arial, sans-serif;
   font-size: 18px;
-  color: #494949;
+  color: #313132;
   background: white;
   box-shadow: none;
   border: 2px solid #606060;

--- a/components/dropdown/sample.html
+++ b/components/dropdown/sample.html
@@ -26,7 +26,7 @@
     .bc-gov-dropdown {
       font-family: "Noto Sans", Verdana, Arial, sans-serif;
       font-size: 18px;
-      color: #494949;
+      color: #313132;
       background: white;
       box-shadow: none;
       border: 2px solid #606060;

--- a/components/dropdown/style.css
+++ b/components/dropdown/style.css
@@ -16,7 +16,7 @@ body {
 .bc-gov-dropdown {
   font-family: "Noto Sans", Verdana, Arial, sans-serif;
   font-size: 18px;
-  color: #494949;
+  color: #313132;
   background: white;
   box-shadow: none;
   border: 2px solid #606060;

--- a/components/primary_button/README.md
+++ b/components/primary_button/README.md
@@ -6,7 +6,7 @@ author: orinevares
 ---
 
 ![Status](https://img.shields.io/badge/Recommended-Draft-orange.svg)
-> Last Updated: February 11, 2019
+> Last Updated: April 30, 2020
 
 # Primary Button
 Primary buttons allow users to carry out an important action on your service, such as Download or Submit.
@@ -101,7 +101,7 @@ As read using ChromeVox
     background-color: #fff;
     border: none;
     border-radius: 4px;
-    color: #494949;
+    color: #313132;
     padding: 12px 32px;
     text-align: center;
     text-decoration: none;

--- a/components/primary_button/sample-dark.html
+++ b/components/primary_button/sample-dark.html
@@ -11,7 +11,7 @@
       background-color: #fff;
       border: none;
       border-radius: 4px;
-      color: #494949;
+      color: #313132;
       padding: 12px 32px;
       text-align: center;
       text-decoration: none;

--- a/components/primary_button/style-dark.css
+++ b/components/primary_button/style-dark.css
@@ -2,7 +2,7 @@
     background-color: #fff;
     border: none;
     border-radius: 4px;
-    color: #494949;
+    color: #313132;
     padding: 12px 32px;
     text-align: center;
     text-decoration: none;

--- a/components/secondary_button/README.md
+++ b/components/secondary_button/README.md
@@ -6,7 +6,7 @@ author: orinevares
 ---
 
 ![Status](https://img.shields.io/badge/Recommended-Draft-orange.svg)
-> Last Updated: March 27, 2019
+> Last Updated: April 30, 2020
 
 # Secondary Button
 Secondary buttons allow users to carry out a supporting action on your service, such as Back or Cancel.
@@ -116,7 +116,7 @@ As read using ChromeVox
 .BC-Gov-SecondaryButton-Dark:hover {
     text-decoration: underline;
     background-color: #fff;
-    color: #494949;
+    color: #313132;
     }
 
 :focus {
@@ -126,7 +126,7 @@ As read using ChromeVox
 
 .BC-Gov-SecondaryButton-Dark:active {
     background-color: #f2f2f2;
-    color: #494949;
+    color: #313132;
     }
 
 .background-colour {

--- a/components/secondary_button/sample-dark.html
+++ b/components/secondary_button/sample-dark.html
@@ -26,7 +26,7 @@
     .BC-Gov-SecondaryButton-Dark:hover {
         text-decoration: underline;
         background-color: #fff;
-        color: #494949;
+        color: #313132;
      }
 
     :focus {
@@ -36,7 +36,7 @@
 
     .BC-Gov-SecondaryButton-Dark:active {
         background-color: #f2f2f2;
-        color: #494949;
+        color: #313132;
      }
 
     .background-colour {

--- a/components/secondary_button/style-dark.css
+++ b/components/secondary_button/style-dark.css
@@ -17,7 +17,7 @@
 .BC-Gov-SecondaryButton-Dark:hover {
     text-decoration: underline;
     background-color: #fff;
-    color: #494949;
+    color: #313132;
     }
 
 :focus {
@@ -27,7 +27,7 @@
 
 .BC-Gov-SecondaryButton-Dark:active {
     background-color: #f2f2f2;
-    color: #494949;
+    color: #313132;
     }
 
 .background-colour {

--- a/styles/colours/colourpalette.md
+++ b/styles/colours/colourpalette.md
@@ -15,21 +15,20 @@ The B.C. Government colour palette ensures all public facing government services
   <h3>Primary B.C. Brand</h3>
   <div class="row">
     <div class="col-sm-4">
-    <div class="card">
+      <div class="card">
         <div class="p-3 text-white" style="background-color: #003366; height: 150px;">#003366</div>
         <div class="card-body">
-          <p class="mb-0">Used for <a href="https://developer.gov.bc.ca/Design-System/Header-Basic">header</a>, <a href="https://developer.gov.bc.ca/Design-System/Footer-Basic">footer</a>,
-             <a href="https://developer.gov.bc.ca/Design-System/Primary-Button">primary button</a></p>
+          <p class="mb-0">Used for <a href="https://developer.gov.bc.ca/Design-System/Header-Basic">header</a>, <a href="https://developer.gov.bc.ca/Design-System/Footer-Basic">footer</a>, <a href="https://developer.gov.bc.ca/Design-System/Primary-Button">primary button</a></p>
         </div>
-    </div>
+      </div>
     </div>
     <div class="col-sm-4">
-    <div class="card">
+      <div class="card">
         <div class="p-3 text-black" style="background-color: #FCBA19; height: 150px;">#FCBA19</div>
         <div class="card-body">
           <p class="mb-0">Used for <a href="https://developer.gov.bc.ca/Design-System/Header-Basic">header</a>, <a href="https://developer.gov.bc.ca/Design-System/Footer-Basic">footer</a>, beta status</p>
         </div>
-    </div>
+      </div>
     </div>
   </div>
 </div>
@@ -38,12 +37,12 @@ The B.C. Government colour palette ensures all public facing government services
   <h3>Text</h3>
   <div class="row">
     <div class="col-sm-4">
-    <div class="card">
+      <div class="card">
         <div class="p-3 text-white" style="background-color: #494949; height: 150px;">#494949</div>
         <div class="card-body">
           <p class="mb-0">Used for <a href="https://developer.gov.bc.ca/Design-System/Typography">headings and paragraphs</a></p>
         </div>
-    </div>
+      </div>
     </div>
   </div>
 </div>
@@ -52,12 +51,12 @@ The B.C. Government colour palette ensures all public facing government services
   <h3>Links</h3>
   <div class="row">
     <div class="col-sm-4">
-    <div class="card">
+      <div class="card">
         <div class="p-3 text-white" style="background-color: #1A5A96; height: 150px;">#1A5A96</div>
         <div class="card-body">
           <p class="mb-0">Used for <a href="https://developer.gov.bc.ca/Design-System/Links">links</a></p>
         </div>
-    </div>
+      </div>
     </div>
   </div>
 </div>
@@ -66,20 +65,20 @@ The B.C. Government colour palette ensures all public facing government services
   <h3>Backgrounds</h3>
   <div class="row">
     <div class="col-sm-4">
-    <div class="card">
+      <div class="card">
         <div class="p-3 text-white" style="background-color: #38598A; height: 150px;">#38598A</div>
         <div class="card-body">
           <p class="mb-0">Used for <a href="https://developer.gov.bc.ca/Design-System/Navigation-Bar-Basic">navigation bar</a></p>
         </div>
-    </div>
+      </div>
     </div>
     <div class="col-sm-4">
-    <div class="card">
+      <div class="card">
         <div class="p-3 text-black" style="background-color: #F2F2F2; height: 150px;">#F2F2F2</div>
         <div class="card-body">
           <p class="mb-0">Used for backgrounds</p>
         </div>
-    </div>
+      </div>
     </div>
   </div>
 </div>
@@ -88,15 +87,13 @@ The B.C. Government colour palette ensures all public facing government services
   <h3>Components</h3>
   <div class="row">
     <div class="col-sm-4">
-    <div class="card">
+      <div class="card">
         <div class="p-3 text-white" style="background-color: #606060; height: 150px;">#606060</div>
         <div class="card-body">
-          <p class="mb-0">Used for 
-              <a href="https://developer.gov.bc.ca/Design-System/Text-Input">text input</a>,
-              <a href="https://developer.gov.bc.ca/Design-System/Textarea">textarea</a>, <a href="https://developer.gov.bc.ca/Design-System/Checkbox">checkbox</a>,
-             <a href="https://developer.gov.bc.ca/Design-System/Radio-Button">radio button</a>
-        </p>
+          <p class="mb-0">Used for <a href="https://developer.gov.bc.ca/Design-System/Text-Input">text input</a>, <a href="https://developer.gov.bc.ca/Design-System/Textarea">textarea</a>, <a href="https://developer.gov.bc.ca/Design-System/Checkbox">checkbox</a>, <a href="https://developer.gov.bc.ca/Design-System/Radio-Button">radio button</a></p>
         </div>
+      </div>
+    </div>
   </div>
 </div>
 
@@ -104,20 +101,20 @@ The B.C. Government colour palette ensures all public facing government services
   <h3>Semantic Colours</h3>
   <div class="row">
     <div class="col-sm-4">
-    <div class="card">
+      <div class="card">
         <div class="p-3 text-white" style="background-color: #D8292F; height: 150px;">#D8292F</div>
         <div class="card-body">
           <p class="mb-0">Used for error messages and indicators</p>
         </div>
-    </div>
+      </div>
     </div>
     <div class="col-sm-4">
-    <div class="card">
+      <div class="card">
         <div class="p-3 text-white" style="background-color: #2E8540; height: 150px;">#2E8540</div>
         <div class="card-body">
           <p class="mb-0">Used for success messages and indicators</p>
         </div>
-    </div>
+      </div>
     </div>
   </div>
 </div>

--- a/styles/colours/colourpalette.md
+++ b/styles/colours/colourpalette.md
@@ -4,7 +4,7 @@ title: Colour Palette
 status: draft
 ---
 ![Status](https://img.shields.io/badge/Recommended-Draft-orange.svg)
-> Last Updated: February 20, 2019
+> Last Updated: April 30, 2020
 
 # Colour Palette
 
@@ -38,7 +38,7 @@ The B.C. Government colour palette ensures all public facing government services
   <div class="row">
     <div class="col-sm-4">
       <div class="card">
-        <div class="p-3 text-white" style="background-color: #494949; height: 150px;">#494949</div>
+        <div class="p-3 text-white" style="background-color: #313132; height: 150px;">#313132</div>
         <div class="card-body">
           <p class="mb-0">Used for <a href="https://developer.gov.bc.ca/Design-System/Typography">headings and paragraphs</a></p>
         </div>

--- a/styles/typography/paragraph-sample.html
+++ b/styles/typography/paragraph-sample.html
@@ -15,7 +15,7 @@
       font-size: 16px;
       line-height: 1.6;
       margin-bottom: 36px;
-      color: #494949;
+      color: #313132;
     }
     </style>
   </head>

--- a/styles/typography/typography.md
+++ b/styles/typography/typography.md
@@ -5,6 +5,7 @@ status: draft
 ---
 
 ![Status](https://img.shields.io/badge/Recommended-Draft-orange.svg)
+> Last Updated: April 30, 2020
 
 # Typography
 
@@ -103,7 +104,7 @@ p {
   font-size: 16px;
   line-height: 1.6;
   margin-bottom: 36px;
-  color: #494949;
+  color: #313132;
 }
 ```
 


### PR DESCRIPTION
This pull request closes #237, updating the [Colour Palette](https://developer.gov.bc.ca/Design-System/Colour-Palette) to reflect the change in text color for paragraphs and headings from `#494949` to the darker `#313132` already in use in production on gov.bc.ca.

- Linting and documentation update in `styles/colours/colourpalette.md`
- Update code samples throughout the repository (`#494949` no longer appears in the repo)

I'm confident in replacing `#494949` completely, as the production gov.bc.ca site is only using this older color in three selectors from my searching:

- [enSearch.css](https://www2.gov.bc.ca/StaticWebResources/static/search/css/enSearch.css)
  - `.facet-container-heading i.facet-container-title`: "Refine by" label in search result left bar
  - `.facet-group-heading i.facet-group-title`: "Title" label in search result left bar
  - `.result_item a.result_wrapper`: Search result link text that gets over-written by a more specific selector colored with `#1a5a96`
- [highlightKeyword.css](https://www2.gov.bc.ca/StaticWebResources/static/shared/css/highlightKeyword.css)
  - `div.highlightFeedbackLink a`: Couldn't find this in use