### PR TITLE
Fix Header - Basic component samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,3 @@ Thumbs.db
 
 # Fonts
 MyriadWebPro.*
-components/about/accessibility.md

--- a/components/header/README.md
+++ b/components/header/README.md
@@ -38,10 +38,10 @@ The text in the header should include the site title or service name. If the web
 * Not be brand-driven or focused on marketing
 
 Good examples include:
-*	Apply for MSP
-*	Get help with court fees
-*	Renew your license
-*	Find a career
+* Apply for MSP
+* Get help with court fees
+* Renew your license
+* Find a career
 
 *Adapted from the UK Government’s [Service Naming Guide](https://www.gov.uk/service-manual/design/naming-your-service)
 
@@ -50,7 +50,7 @@ This header matches the mandatory branding requirements of the BC Government. Co
 
 ## Behaviour
 
-1. Clicking on B.C. government logo links the user back to the homepage of your service 
+1. Clicking on B.C. government logo links the user back to the homepage of your service
 
 ### Mobile Design
 1. Logo and title shrink until mobile size
@@ -77,24 +77,24 @@ As read using ChromeVox
 <!--
   All in-line CSS is specific to this sample; it can and should be ignored.
  -->
-  <header>
-    <div class="banner">
-        <a href="https://gov.bc.ca" alt="British Columbia">
-          <img src="../assets/images/BCID_H_rgb_rev.svg" alt="Go to the Government of British Columbia website" />
-        </a>
-        <h1>Hello British Columbia</h1>
-    </div>
-    <div class="other">
-    <!-- 
-      This place is for anything that needs to be right aligned
-      beside the logo.  
-    -->
-      &nbsp;
-    </div>
-    </div>
-  </header>
+<header>
+  <div class="banner">
+    <a href="https://gov.bc.ca" alt="British Columbia">
+      <img src="../assets/images/BCID_H_rgb_rev.svg" alt="Go to the Government of British Columbia website" />
+    </a>
+    <h1>Hello British Columbia</h1>
+  </div>
+  <div class="other">
+  <!--
+    This place is for anything that needs to be right aligned
+    beside the logo.
+  -->
+    &nbsp;
+  </div>
+  </div>
+</header>
 ```
-    
+
 ### CSS
 
 ```css
@@ -138,7 +138,7 @@ header .other {
 /*
   These are sample media queries only. Media queries are quite subjective
   but, in general, should be made for the three different classes of screen
-  size: phone, tablet, full. 
+  size: phone, tablet, full.
 */
 
 @media screen and (min-width: 600px) and (max-width: 899px) {
@@ -155,6 +155,7 @@ header .other {
   }
 }
 ```
+
 ### Assets
-1.	Logo
-2.	Font download or reference link
+1. Logo
+2. Font download or reference link

--- a/components/header/README.md
+++ b/components/header/README.md
@@ -79,7 +79,7 @@ As read using ChromeVox
  -->
 <header>
   <div class="banner">
-    <a href="https://gov.bc.ca" alt="British Columbia">
+    <a href="https://gov.bc.ca">
       <img src="../assets/images/BCID_H_rgb_rev.svg" alt="Go to the Government of British Columbia website" />
     </a>
     <h1>Hello British Columbia</h1>
@@ -90,7 +90,6 @@ As read using ChromeVox
     beside the logo.
   -->
     &nbsp;
-  </div>
   </div>
 </header>
 ```

--- a/components/header/index.html
+++ b/components/header/index.html
@@ -14,8 +14,8 @@
 <body>
   <header>
     <div class="banner">
-      <a href="https://gov.bc.ca" alt="British Columbia">
-        <img src="../assets/images/logo-banner.svg" alt="Go to the Government of British Columbia website" />
+      <a href="https://gov.bc.ca">
+        <img src="../assets/images/logo-banner.svg" alt="Go to the Government of British Columbia website" height="50px"/>
       </a>
       <h1>Hello British Columbia</h1>
     </div>
@@ -25,7 +25,6 @@
       beside the logo.
     -->
       &nbsp;
-    </div>
     </div>
   </header>
 </body>

--- a/components/header/index.html
+++ b/components/header/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/css/bootstrap-reboot.min.css" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Noto+Sans" rel="stylesheet">
-    <link rel="stylesheet" href="style.css">
-    <title>Sample Header</title>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/css/bootstrap-reboot.min.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Noto+Sans" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <title>Sample Header</title>
 </head>
 
 <!--
@@ -14,15 +14,15 @@
 <body>
   <header>
     <div class="banner">
-        <a href="https://gov.bc.ca" alt="British Columbia">
-          <img src="../assets/images/logo-banner.svg" alt="Go to the Government of British Columbia website" />
-        </a>
-        <h1>Hello British Columbia</h1>
+      <a href="https://gov.bc.ca" alt="British Columbia">
+        <img src="../assets/images/logo-banner.svg" alt="Go to the Government of British Columbia website" />
+      </a>
+      <h1>Hello British Columbia</h1>
     </div>
     <div class="other">
-    <!-- 
+    <!--
       This place is for anything that needs to be right aligned
-      beside the logo.  
+      beside the logo.
     -->
       &nbsp;
     </div>

--- a/components/header/sample.html
+++ b/components/header/sample.html
@@ -77,7 +77,7 @@
 <body>
   <header>
     <div class="banner">
-      <a href="https://gov.bc.ca" alt="British Columbia">
+      <a href="https://gov.bc.ca">
         <img src="https://developer.gov.bc.ca/static/BCID_H_rgb_rev-20eebe74aef7d92e02732a18b6aa6bbb.svg" alt="Go to the Government of British Columbia website" height="50px"/>
       </a>
       <h1>Hello British Columbia</h1>
@@ -88,7 +88,6 @@
       beside the logo.
     -->
       &nbsp;
-    </div>
     </div>
   </header>
 </body>

--- a/components/header/sample.html
+++ b/components/header/sample.html
@@ -1,73 +1,73 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/css/bootstrap-reboot.min.css" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Noto+Sans" rel="stylesheet">
-    <link rel="stylesheet" href="style.css">
-    <title>Sample Header</title>
-    <style>
-          header {
-          background-color: #036;
-          border-bottom: 2px solid #fcba19;
-          padding: 0 65px 0 65px;
-          color: #fff;
-          display: flex;
-          height: 65px;
-          top: 0px;
-          position: fixed;
-          width: 100%;
-        }
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/css/bootstrap-reboot.min.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Noto+Sans" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <title>Sample Header</title>
+  <style>
+    header {
+      background-color: #036;
+      border-bottom: 2px solid #fcba19;
+      padding: 0 65px 0 65px;
+      color: #fff;
+      display: flex;
+      height: 65px;
+      top: 0px;
+      position: fixed;
+      width: 100%;
+    }
 
-        header h1 {
-          font-family: "Noto Sans", Verdana, Arial, sans-serif;
-          font-weight: normal;  /* 400 */
-          margin: 5px 5px 0 18px;
-          visibility: hidden;
-        }
+    header h1 {
+      font-family: "Noto Sans", Verdana, Arial, sans-serif;
+      font-weight: normal;  /* 400 */
+      margin: 5px 5px 0 18px;
+      visibility: hidden;
+    }
 
-        header .banner {
-          display: flex;
-          justify-content: flex-start;
-          align-items: center;
-          margin: 0 10px 0 0;
-          /* border-style: dotted;
-          border-width: 1px;
-          border-color: lightgrey; */
-        }
+    header .banner {
+      display: flex;
+      justify-content: flex-start;
+      align-items: center;
+      margin: 0 10px 0 0;
+      /* border-style: dotted;
+      border-width: 1px;
+      border-color: lightgrey; */
+    }
 
-        header .other {
-          display: flex;
-          flex-grow: 1;
-          /* border-style: dotted;
-          border-width: 1px;
-          border-color: lightgrey; */
-        }
+    header .other {
+      display: flex;
+      flex-grow: 1;
+      /* border-style: dotted;
+      border-width: 1px;
+      border-color: lightgrey; */
+    }
 
-        :focus {
-          outline: 4px solid #3B99FC;
-          outline-offset: 1px;
-        }
+    :focus {
+      outline: 4px solid #3B99FC;
+      outline-offset: 1px;
+    }
 
-        /*
-          These are sample media queries only. Media queries are quite subjective
-          but, in general, should be made for the three different classes of screen
-          size: phone, tablet, full. 
-        */
+    /*
+      These are sample media queries only. Media queries are quite subjective
+      but, in general, should be made for the three different classes of screen
+      size: phone, tablet, full.
+    */
 
-        @media screen and (min-width: 600px) and (max-width: 899px) {
-          header h1 {
-            font-size: calc(7px + 2.2vw);
-            visibility: visible;
-          }
-        }
+    @media screen and (min-width: 600px) and (max-width: 899px) {
+      header h1 {
+        font-size: calc(7px + 2.2vw);
+        visibility: visible;
+      }
+    }
 
-        @media screen and (min-width: 900px) {
-          header h1 {
-            font-size: 2.0em;
-            visibility: visible;
-          }
-        }
-    </style>
+    @media screen and (min-width: 900px) {
+      header h1 {
+        font-size: 2.0em;
+        visibility: visible;
+      }
+    }
+  </style>
 </head>
 
 <!--
@@ -77,15 +77,15 @@
 <body>
   <header>
     <div class="banner">
-        <a href="https://gov.bc.ca" alt="British Columbia">
-          <img src="https://developer.gov.bc.ca/static/BCID_H_rgb_rev-20eebe74aef7d92e02732a18b6aa6bbb.svg" alt="Go to the Government of British Columbia website" height="50px"/>
-        </a>
-        <h1>Hello British Columbia</h1>
+      <a href="https://gov.bc.ca" alt="British Columbia">
+        <img src="https://developer.gov.bc.ca/static/BCID_H_rgb_rev-20eebe74aef7d92e02732a18b6aa6bbb.svg" alt="Go to the Government of British Columbia website" height="50px"/>
+      </a>
+      <h1>Hello British Columbia</h1>
     </div>
     <div class="other">
-    <!-- 
+    <!--
       This place is for anything that needs to be right aligned
-      beside the logo.  
+      beside the logo.
     -->
       &nbsp;
     </div>

--- a/components/header/style.css
+++ b/components/header/style.css
@@ -43,7 +43,7 @@ header .other {
 /*
   These are sample media queries only. Media queries are quite subjective
   but, in general, should be made for the three different classes of screen
-  size: phone, tablet, full. 
+  size: phone, tablet, full.
 */
 
 @media screen and (min-width: 600px) and (max-width: 899px) {


### PR DESCRIPTION
This pull request fixes #242, updating the [Header - Basic](https://developer.gov.bc.ca/Design-System/Header-Basic) component:

- Fixes whitespace throughout component documentation and code
- Removes extraneous `</div>` tags in `README.md`, `index.html`, and `sample.html`
- Removes `alt` attributes from `<a>` tags in code samples, as `alt` isn't a [content attribute for `<a>` tags](https://html.spec.whatwg.org/multipage/dom.html#concept-element-attributes) or a [global attribute for HTML elements](https://html.spec.whatwg.org/multipage/dom.html#global-attributes) generally

Unrelated fix:
- Removes [Accessibility](https://developer.gov.bc.ca/Design-System/Accessibility) documentation from `.gitignore`