### PR TITLE
Refactor XD file link to Markdown format

### DIFF
--- a/components/about/prototyping_tools.md
+++ b/components/about/prototyping_tools.md
@@ -9,5 +9,5 @@ author: orinevares
 ## Adobe XD
 ![Status](https://img.shields.io/badge/Community%20Contribution-v1.0-blue)
 
-The design system components have been created in Adobe XD by a community memeber to use for mockups and prototyping.
-<a href="https://github.com/bcgov/design-system/blob/master/assets/Design-System-v6.xd" download>Download XD File</a>
+The design system components have been created in Adobe XD by a community member to use for mockups and prototyping.
+[Download XD File](https://github.com/bcgov/design-system/raw/master/assets/Design-System-v6.xd)


### PR DESCRIPTION
This PR changes the Adobe XD asset link on the "Prototype with the Design System" page to use Markdown format. The underlying URL is changed to point to the `/raw` (vs `/blob`) route on GitHub to trigger direct download functionality.