### PR TITLE
Update Alert Banner component guidance

### DIFF
--- a/components/alert_banners/README.md
+++ b/components/alert_banners/README.md
@@ -1,19 +1,18 @@
 ---
-description: Alert banners notify users of important information or changes on a page.
+description: Alert banners notify people of important information or changes on a page.
 title: Alert Banners
-author: dlevine
 ---
 
-> Last Updated: September 15, 2020
+> Last Updated: July 7, 2021
 
 # Alert Banners
-Alert banners notify users of important information or changes on a page. Typically, they appear at the top of a page.
+Alert banners notify people of important information or changes on a page. Typically, they appear at the top of a page.
 
 ## Example
 <component-preview path="components/alert_banners/sample.html" height="400px" width="800px"> </component-preview>
 
 ## Use This For
-Telling users important and typically time sensitive information. This includes:
+Telling people important and typically time sensitive information. This includes:
 
 - Success messages
 - Error messages
@@ -27,15 +26,15 @@ Telling users important and typically time sensitive information. This includes:
 - Highlighting content, quotes, examples, snippets of information. Use a [callout component](https://developer.gov.bc.ca/Design-System/Callout) instead
 
 ## Design Guidance
-- You can only use one alert on a page. If you want to use two alerts, contact your GCPE communications shop for guidance.
+- You can only use one alert on a page.
 - Do not include alerts that are not related to the persons current goal or specific page content
-- If a user is required to do something in response to an alert, let them know what they need to do and make that task as easy as possible. For example, provide them a link to something in the alert.
+- If a person is required to do something in response to an alert, let them know what they need to do and make that task as easy as possible. For example, provide them a link to something in the alert.
 - Write messages in a concise manner while avoiding the use of jargon and technical language.
-- Do not write lots of text. Too much text will cause users to ignore the content.
-- Allow users the ability to dismiss alerts when appropriate.
+- Do not write lots of text. Too much text will cause people to ignore the content.
+- Allow people the ability to dismiss alerts when appropriate.
 
 ### Error Alert
-Use error alerts if a service is cancelled, there's a risk to health or safety to people in completing an activity, or with form validation errors that will block the user from completing their task.
+Use error alerts if a service is cancelled, there's a risk to health or safety to people in completing an activity, or with form validation errors that will block the person from completing their task.
 
 ### Warning Alert
 Use warning alerts when there is something urgent or to help someone avoid a problem for things like delays, closures at certain locations, and other types of service disruptions.


### PR DESCRIPTION
This pull request updates the Design System's [alert banner component guidance](https://developer.gov.bc.ca/Alert-Banners) to bring it in line with the updated [Web Style Guide alert guidance](https://www2.gov.bc.ca/gov/content/governments/services-for-government/service-experience-digital-delivery/web-content-development-guides/web-style-guide/writing-guide/formatting#alerts) following input from the Service & Content Design team.

- Removes reference to [requests for multiple alerts](https://github.com/bcgov/design-system/compare/master...ty2k:content/update-alert-banner-guidance?expand=1#diff-4f20d3e648d9950d6ecdfa0712bb6beb1942f734eea32d5a8a604fc3e76e394fL30) as we want to reinforce that no more than one alert should be used per page
- Updates language from "user"/"users" to "person"/"people"