### PR TITLE
Don't copy package-lock.json in Storybook Dockerfile

### DIFF
--- a/packages/react-components/Dockerfile.storybook
+++ b/packages/react-components/Dockerfile.storybook
@@ -7,7 +7,7 @@ FROM node:lts-alpine as build-stage
 
 # Copy package.json and package-lock.json
 WORKDIR /app
-COPY package*.json .
+COPY package.json .
 
 # Print npm config
 RUN npm config list


### PR DESCRIPTION
This PR updates the React component library's Storybook Dockerfile to fix a broken build.

Prior to this PR, the Dockerfile will fail to build with this error:

```
> @bcgov/design-system-react-components@0.0.3 storybook-build
> storybook build

@storybook/cli v8.0.0-alpha.17

info => Cleaning outputDir: storybook-static
info => Loading presets
info => Building manager..
info => Manager built (1.21 s)
info => Building preview..
=> Failed to build the preview
Error: Cannot find module @rollup/rollup-linux-x64-musl. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). Please try `npm i` again after removing both package-lock.json and node_modules directory.
    at requireWithFriendlyError (./node_modules/rollup/dist/native.js:87:9)
    at Object.<anonymous> (./node_modules/rollup/dist/native.js:96:48)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
    at Object.newLoader (./node_modules/esbuild-register/dist/node.js:2262:9)
    at extensions..js (./node_modules/esbuild-register/dist/node.js:4838:24)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at cjsLoader (node:internal/modules/esm/translators:356:17)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:305:7)
/app/node_modules/@storybook/cli/bin/index.js:23
  throw error;
  ^

Error: Cannot find module @rollup/rollup-linux-x64-musl. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). Please try `npm i` again after removing both package-lock.json and node_modules directory.
    at requireWithFriendlyError (/app/node_modules/rollup/dist/native.js:87:9)
    at Object.<anonymous> (/app/node_modules/rollup/dist/native.js:96:48)
    ... 3 lines matching cause stack trace ...
    at extensions..js (/app/node_modules/esbuild-register/dist/node.js:4838:24)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at cjsLoader (node:internal/modules/esm/translators:356:17)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:305:7) {
  [cause]: Error: Cannot find module '@rollup/rollup-linux-x64-musl'
  Require stack:
  - /app/node_modules/rollup/dist/native.js
      at Module._resolveFilename (node:internal/modules/cjs/loader:1144:15)
      at Module._load (node:internal/modules/cjs/loader:985:27)
      at Module.require (node:internal/modules/cjs/loader:1235:19)
      at require (node:internal/modules/helpers:176:18)
      at requireWithFriendlyError (/app/node_modules/rollup/dist/native.js:69:10)
      at Object.<anonymous> (/app/node_modules/rollup/dist/native.js:96:48)
      at Module._compile (node:internal/modules/cjs/loader:1376:14)
      at Module._extensions..js (node:internal/modules/cjs/loader:1435:10)
      at Object.newLoader (/app/node_modules/esbuild-register/dist/node.js:2262:9)
      at extensions..js (/app/node_modules/esbuild-register/dist/node.js:4838:24) {
    code: 'MODULE_NOT_FOUND',
    requireStack: [ '/app/node_modules/rollup/dist/native.js' ]
  }
}

Node.js v20.11.0
error: build error: building at STEP "RUN npm run storybook-build": while running runtime: exit status 7
```

By only copying package.json (not the package-lock.json) in the Dockerfile, I find the build succeeds locally.