### PR TITLE
Don't copy package-lock.json in Vite Dockerfile

### DIFF
--- a/packages/react-components/Dockerfile.vite
+++ b/packages/react-components/Dockerfile.vite
@@ -7,7 +7,7 @@ FROM node:lts-alpine as build-stage
 
 # Copy package.json and package-lock.json
 WORKDIR /app
-COPY package*.json .
+COPY package.json .
 
 # Print npm config
 RUN npm config list


### PR DESCRIPTION
Like #286, this PR prevents the package-lock.json file from being used in the Dockerfile for the Vite app build. This change fixes the build locally for me.