### PR TITLE
Update default branch reference in v1 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The [B.C. Design Tokens package](https://github.com/bcgov/design-system/tree/doc
 Design tokens provide a method to quickly and consistently implement the province's look and feel for digital services. They offer a set of standardized options to help developers style user interfaces in a consistent and future-proof way.
 
 * [Installable package on npm](https://www.npmjs.com/package/@bcgov/design-tokens)
-* [Source code](https://github.com/bcgov/design-system/tree/master/packages/design-tokens)
+* [Source code](https://github.com/bcgov/design-system/tree/main/packages/design-tokens)
 * [Figma library](https://www.figma.com/community/file/1326994583954765832)
 
 ## Component library
@@ -47,7 +47,7 @@ The B.C. Design System is maintained by Government Digital Experience (GDX), a d
 Documentation and components for the legacy design system are accessible in this repo and on DevHub:
 
 * [Developer documentation](https://developer.gov.bc.ca/Design-System/About-the-Design-System)
-* [Source code](https://github.com/bcgov/design-system/tree/master/components)
+* [Source code](https://github.com/bcgov/design-system/tree/main/components)
 
 ## License
 

--- a/components/about/browser_support_guidance.md
+++ b/components/about/browser_support_guidance.md
@@ -78,4 +78,4 @@ If your website or application doesn’t support IE, you can create a page telli
 
 ### Download
 
-* [Images](https://github.com/bcgov/design-system/tree/master/components/assets/unsupported-browsers)
+* [Images](https://github.com/bcgov/design-system/tree/main/components/assets/unsupported-browsers)

--- a/components/about/prototyping_tools.md
+++ b/components/about/prototyping_tools.md
@@ -10,6 +10,6 @@ author: orinevares
 ![Status](https://img.shields.io/badge/Community%20Contribution-v1.0-blue)
 
 The design system components have been created in Adobe XD by a community member to use for mockups and prototyping.
-[Download XD File](https://github.com/bcgov/design-system/raw/master/assets/Design-System-v6.xd)
+[Download XD File](https://github.com/bcgov/design-system/raw/main/assets/Design-System-v6.xd)
 
 A Figma template is also being started [here](https://github.com/bcgov/figma).

--- a/components/header/README.md
+++ b/components/header/README.md
@@ -17,7 +17,7 @@ Headers help people understand what the product or service is about while provid
 <component-preview path="components/header/sample.html" height="100px" width="800px"> </component-preview>
 
 ### Download
-* [BC Gov Logo](https://github.com/bcgov/design-system/tree/master/components/assets/images)
+* [BC Gov Logo](https://github.com/bcgov/design-system/tree/main/components/assets/images)
 
 ## Requirements
 * This header must appear on all public-facing online B.C. Government content and services


### PR DESCRIPTION
This PR updates links in the existing v1 design system documentation to point to the new default branch for this repo `main`.