### PR TITLE
Update legacy design system URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The B.C. Design System is maintained by Government Digital Experience (GDX), a d
 
 Documentation and components for the legacy design system are accessible in this repo and on DevHub:
 
-* [Developer documentation](https://developer.gov.bc.ca/Design-System/About-the-Design-System)
+* [Developer documentation](https://classic.developer.gov.bc.ca/Design-System/About-the-Design-System)
 * [Source code](https://github.com/bcgov/design-system/tree/main/components)
 
 ## License


### PR DESCRIPTION
With the move of Backstage.io from `mvp.developer.gov.bc.ca` to `developer.gov.bc.ca`, this PR updates the URL for the legacy design system.

Without this change, users end up on the new DevHub 404 page:

<img width="1840" alt="DevHub 404" src="https://github.com/bcgov/design-system/assets/25143706/7df8d6eb-3dd7-4567-9726-efbb01de04cc">
