### PR TITLE
Bugfix: Provide Storybook build step with Vite config in Dockerfile

### DIFF
--- a/packages/react-components/.storybook/main.ts
+++ b/packages/react-components/.storybook/main.ts
@@ -9,7 +9,12 @@ const config: StorybookConfig = {
   ],
   framework: {
     name: "@storybook/react-vite",
-    options: {},
+    options: {
+      builder: {
+        viteConfigPath: "vite.config.ts",
+      },
+      strictMode: false,
+    },
   },
 };
 export default config;

--- a/packages/react-components/Dockerfile.storybook
+++ b/packages/react-components/Dockerfile.storybook
@@ -8,6 +8,7 @@ FROM node:lts-alpine as build-stage
 # Copy package.json and package-lock.json
 WORKDIR /app
 COPY package.json .
+COPY vite.config.ts .
 
 # Print npm config
 RUN npm config list


### PR DESCRIPTION
Currently, the deployed Storybook app throws `React is not defined` errors despite being on the latest v8 release candidate version of Storybook.

In this PR, I'm explicitly pointing the Storybook builder to the Vite config file. In the Dockerfile, I'm copying that Vite config file into the working directory where the build occurs.

Running `npm run build-storybook` locally has worked previously because that process had access to the Vite config file. In a Docker build environment, this file was missing (due to not being explicitly copied), and the logs of the build process had no indication of this. 

I can confirm the Storybook app is working for me in these circumstances:

- In dev mode locally on my Mac running `npm run storybook-dev` 
- In build mode locally on my Mac after running `npm run storybook-build` and then serving the resulting static output with `http-serve` from my command line
- In build mode via Docker after building using the Dockerfile.storybook file

Hopefully this is the thing that solves the production `React is not defined` error:
<img width="1840" alt="Screenshot 2024-03-06 at 4 28 47 PM" src="https://github.com/bcgov/design-system/assets/25143706/40da5f9c-d38d-4ed1-91e1-0f48f751d4f7">
