### PR TITLE
Default footer content revisions

### DIFF
--- a/packages/react-components/src/components/Footer/Footer.tsx
+++ b/packages/react-components/src/components/Footer/Footer.tsx
@@ -73,8 +73,7 @@ export default function Footer({
     // https://www2.gov.bc.ca/gov/content/home/services-a-z
     return (
       <p>
-        We can help in over 120 languages and through Telephone Device For The
-        Deaf (TDD).{" "}
+        We can help in over 220 languages and through other accessible options.{" "}
         <a href="https://www2.gov.bc.ca/gov/content?id=6A77C17D0CCB48F897F8598CCC019111">
           Call, email or text us
         </a>

--- a/packages/react-components/src/components/Footer/Footer.tsx
+++ b/packages/react-components/src/components/Footer/Footer.tsx
@@ -55,7 +55,7 @@ export default function Footer({
         The B.C. Public Service acknowledges the territories of First Nations
         around B.C. and is grateful to carry out our work on these lands. We
         acknowledge the rights, interests, priorities, and concerns of all
-        Indigenous Peoples - First Nations, Métis, and Inuit - respecting and
+        Indigenous Peoples — First Nations, Métis, and Inuit — respecting and
         acknowledging their distinct cultures, histories, rights, laws, and
         governments.
       </p>


### PR DESCRIPTION
This PR includes 2 content changes in the default loadout for the footer component:

- f62fc35 corrects a typo in the territorial acknowledgment text (hyphens being used instead of em dashes)
- 0524a57 revises the contact information copy below the B.C. Mark to align with the version currently on gov.bc.ca