### PR TITLE
Update React library rollup script to ensure dist code freshness

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.5",
   "type": "module",
   "scripts": {
-    "rollup": "rollup -c --bundleConfigAsCjs",
+    "rollup": "rm -rf dist && rollup -c --bundleConfigAsCjs",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "storybook-dev": "storybook dev -p 6006",
     "storybook-build": "storybook build",

--- a/packages/react-components/src/components/Footer/Footer.tsx
+++ b/packages/react-components/src/components/Footer/Footer.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { SvgBcLogo } from "..";
+import SvgBcLogo from "../SvgBcLogo";
 
 import "./Footer.css";
 

--- a/packages/react-components/src/components/Header/Header.tsx
+++ b/packages/react-components/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { SvgBcLogo } from "..";
+import SvgBcLogo from "../SvgBcLogo";
 
 import "./Header.css";
 


### PR DESCRIPTION
This PR includes two quality of life updates for the `rollup` script in the React component library:

- 10c77192ab8836735495eded9eb0febd03c43553 The `rollup` script in `package.json` is updated to add `rm -rf dist` so that the `dist` directory is removed prior to generating a new bundle. This is important because by default, the contents of the directory is preserved if a new run of the script doesn't overwrite the individual files. As a result, some files that shouldn't be in the bundle have made their way into it in previous releases, like the BC Sans font:
<img width="1840" alt="NPM screenshot showing the BC Sans font in version 0.0.5 of the React component library" src="https://github.com/bcgov/design-system/assets/25143706/4a75596d-aac6-4728-a4b3-a760f27b9eb0">

- eef69bb6c151f0c6211ea88838051006e8dfdf2c The import statements for the `SvgBcLogo` component are updated in the `Header` and `Footer` to remove a circular dependency from the `rollup` script. This ensures that the serialized code in the bundle file will work as expected without unnecessary duplication (ex: a child element isn't declared before its parent).