### PR TITLE
Refactor Storybook theme to use 3.0.0-rc1 tokens

### DIFF
--- a/packages/react-components/.storybook/bcdsTheme.js
+++ b/packages/react-components/.storybook/bcdsTheme.js
@@ -18,14 +18,19 @@ export default create({
   appBorderColor: tokens.surfaceColorBorderDefault,
   appBorderRadius: tokens.layoutBorderRadiusMedium,
 
+  // Buttons
+  buttonBg: tokens.surfaceColorPrimaryButtonDefault,
+  buttonBorder: tokens.surfaceColorBorderDefault,
+
   // Text colors
   textColor: tokens.typographyColorPrimary,
   textInverseColor: tokens.typographyColorPrimaryInvert,
+  textMutedColor: tokens.typographyColorSecondary,
 
   // Toolbar default and active colors
   barTextColor: tokens.typographyColorSecondary,
   barSelectedColor: tokens.surfaceColorBorderActive,
-  barHoverColor: tokens.surfaceColorMenusHover,
+  barHoverColor: tokens.surfaceColorBorderActive,
   barBg: tokens.surfaceColorBackgroundLightGray,
 
   // Form colors

--- a/packages/react-components/.storybook/bcdsTheme.js
+++ b/packages/react-components/.storybook/bcdsTheme.js
@@ -8,15 +8,15 @@ export default create({
   fontCode: "monospace",
 
   // Colour
-  colorPrimary: tokens.surfaceBrandGold60,
-  colorSecondary: tokens.surfaceBrandBlue100,
+  colorPrimary: tokens.themePrimaryGold,
+  colorSecondary: tokens.themePrimaryBlue,
 
   // UI
-  appBg: tokens.surfaceBackgroundLight,
-  appContentBg: tokens.surfaceBackgroundWhite,
-  appPreviewBg: tokens.surfaceBackgroundWhite,
-  appBorderColor: tokens.surfaceBorderMedium,
-  appBorderRadius: tokens.surfaceBorderRadiusMedium,
+  appBg: tokens.surfaceColorBackgroundLightGray,
+  appContentBg: tokens.surfaceColorBackgroundWhite,
+  appPreviewBg: tokens.surfaceColorBackgroundWhite,
+  appBorderColor: tokens.surfaceColorBorderDefault,
+  appBorderRadius: tokens.layoutBorderRadiusMedium,
 
   // Text colors
   textColor: tokens.typographyColorPrimary,
@@ -24,15 +24,15 @@ export default create({
 
   // Toolbar default and active colors
   barTextColor: tokens.typographyColorSecondary,
-  barSelectedColor: tokens.surfacePrimaryActive,
-  barHoverColor: tokens.surfacePrimaryHover,
-  barBg: tokens.surfaceBackgroundLight,
+  barSelectedColor: tokens.surfaceColorBorderActive,
+  barHoverColor: tokens.surfaceColorMenusHover,
+  barBg: tokens.surfaceColorBackgroundLightGray,
 
   // Form colors
-  inputBg: tokens.surfaceBackgroundLight,
-  inputBorder: tokens.surfaceBorderLight,
+  inputBg: tokens.surfaceColorFormsDefault,
+  inputBorder: tokens.surfaceColorBorderDefault,
   inputTextColor: tokens.typographyColorSecondary,
-  inputBorderRadius: tokens.surfaceBorderRadiusMedium,
+  inputBorderRadius: tokens.layoutBorderRadiusMedium,
 
   base: "light",
   brandTitle: "B.C. Design System",

--- a/packages/react-components/.storybook/bcdsTheme.js
+++ b/packages/react-components/.storybook/bcdsTheme.js
@@ -12,7 +12,7 @@ export default create({
   colorSecondary: tokens.themePrimaryBlue,
 
   // UI
-  appBg: tokens.surfaceColorBackgroundLightGray,
+  appBg: tokens.surfaceColorBackgroundLightBlue,
   appContentBg: tokens.surfaceColorBackgroundWhite,
   appPreviewBg: tokens.surfaceColorBackgroundWhite,
   appBorderColor: tokens.surfaceColorBorderDefault,

--- a/packages/react-components/.storybook/manager.js
+++ b/packages/react-components/.storybook/manager.js
@@ -3,4 +3,5 @@ import bcdsTheme from "./bcdsTheme";
 
 addons.setConfig({
   theme: bcdsTheme,
+  panelPosition: 'bottom',
 });

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bcgov/design-tokens": "^2.0.1",
+        "@bcgov/design-tokens": "^3.0.0-rc1",
         "react-aria-components": "1.1.1"
       },
       "devDependencies": {
@@ -2074,9 +2074,9 @@
       "peer": true
     },
     "node_modules/@bcgov/design-tokens": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@bcgov/design-tokens/-/design-tokens-2.0.1.tgz",
-      "integrity": "sha512-TCC2PlTTSplfBgZYR/KOVEWPdqi7QkoxMazVGgO8PTd1NeCwkN+wCTFtkGuzo7JjVAAu7SwCt3RGnR9mluArkQ=="
+      "version": "3.0.0-rc1",
+      "resolved": "https://registry.npmjs.org/@bcgov/design-tokens/-/design-tokens-3.0.0-rc1.tgz",
+      "integrity": "sha512-Zviyhutjnr2KJez3xHl7uTFs/OI2bC7sMYcOeVnkzFxI4PUE38GFY0i18/AraPtMoeV+77jvlm8HziOeauSSTA=="
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -18,7 +18,7 @@
   ],
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@bcgov/design-tokens": "^2.0.1",
+    "@bcgov/design-tokens": "^3.0.0-rc1",
     "react-aria-components": "1.1.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
This change updates the `bcdsTheme` implemented in #299 to use the latest version of the design tokens package (3.0.0-rc1). 

It also includes a small tweak to the Storybook UI layout (72d205b), setting the control panel in story view to appear at the bottom of the screen, rather than as a sidebar on the right-hand side.