### PR TITLE
Fix TooltipProps exports for Vite build

### DIFF
--- a/packages/react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   OverlayArrow,
   Tooltip as ReactAriaTooltip,
@@ -26,19 +25,17 @@ function SvgTooltipArrowUp() {
   );
 }
 
-export default function Tooltip({
-  children,
-  ...props
-}: React.PropsWithChildren<TooltipProps>) {
+export default function Tooltip(props: TooltipProps) {
   return (
     <ReactAriaTooltip className="bcds-react-aria-Tooltip" {...props}>
       <OverlayArrow className="bcds-react-aria-OverlayArrow">
         {/* Up arrow gets rotated by CSS depending on `data-placement` attribute */}
         <SvgTooltipArrowUp />
       </OverlayArrow>
-      {children}
+      <>{props.children}</>
     </ReactAriaTooltip>
   );
 }
 
 export { TooltipTrigger };
+export type { TooltipProps };

--- a/packages/react-components/src/pages/Tooltip/Tooltip.tsx
+++ b/packages/react-components/src/pages/Tooltip/Tooltip.tsx
@@ -3,8 +3,9 @@ import { useButton, mergeProps } from "react-aria";
 import { Button, Tooltip, TooltipTrigger } from "@/components";
 
 // https://github.com/adobe/react-spectrum/issues/5733
-function TooltipTriggerElement(props) {
-  const triggerRef = React.useRef();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function TooltipTriggerElement(props: any) {
+  const triggerRef = React.useRef(null);
   const { buttonProps } = useButton(props, triggerRef);
 
   return React.cloneElement(


### PR DESCRIPTION
This PR has two minor changes to make the Vite build succeed:

- The Tooltips component has its props simplified to use the `TooltipProps` interface from React Aria Components, rather than extending it manually with `children`. The `TooltipProps` interface also gets exported from the component file. This has no practical effect on how the component is used, but it lets the Vite kitchen sink app build access the `TooltipProps` interface during its build (it needs this to succeed). f855e0db29f55852a847633509661b0c1e2284a7
- An instance of the Tooltip component using a custom component for a trigger is present in the Vite kitchen sink app. This is breaking the app's build because of strict type checking on the `TooltipTriggerElement` component, which I have now set to use `any` type to let this just work for now. This code is not part of the component library, but illustrates how we might be able to use the Tooltip in the CMS prototype for its Abbreviation component. 037402280a4328680e9006c80a4d311e06063be7

Since the Tooltip's API doesn't change, I'm not going to bother making a release of the component library just for this change. I need these changes in `main` to be able to build the Vite app.