### PR TITLE
Update Tooltip component to use v3 design tokens

### DIFF
--- a/packages/react-components/src/components/Tooltip/Tooltip.css
+++ b/packages/react-components/src/components/Tooltip/Tooltip.css
@@ -1,6 +1,6 @@
 .bcds-react-aria-Tooltip {
-  background-color: var(--surface-brand-gray-110);
-  border-radius: var(--surface-border-radius-medium);
+  background-color: var(--theme-gray-110);
+  border-radius: var(--layout-border-radius-medium);
   box-shadow: var(--surface-shadow-small);
   color: var(--typography-color-primary-invert);
   font: var(--typography-regular-label);
@@ -9,7 +9,7 @@
 }
 
 .bcds-react-aria-Tooltip > .bcds-react-aria-OverlayArrow {
-  color: var(--surface-brand-gray-110);
+  color: var(--theme-gray-110);
 }
 
 .bcds-react-aria-Tooltip[data-placement="top"] > .bcds-react-aria-OverlayArrow,
@@ -29,10 +29,10 @@
 
 /* Top placement */
 .bcds-react-aria-Tooltip[data-placement="top"] {
-  margin-bottom: 10px; /* Offset is equal to the depth of the OverlayArrow */
+  margin-bottom: 10px; /* This offsets the depth of the OverlayArrow */
 }
 .bcds-react-aria-Tooltip[data-placement="top"] > .bcds-react-aria-OverlayArrow {
-  margin-top: -7.5px;
+  margin-top: -4.5px;
 }
 .bcds-react-aria-Tooltip[data-placement="top"]
   > .bcds-react-aria-OverlayArrow
@@ -46,8 +46,7 @@
 }
 .bcds-react-aria-Tooltip[data-placement="right"]
   > .bcds-react-aria-OverlayArrow {
-  margin-top: -2px;
-  margin-right: 4.5px;
+  margin-right: 5px;
 }
 .bcds-react-aria-Tooltip[data-placement="right"]
   > .bcds-react-aria-OverlayArrow
@@ -57,11 +56,11 @@
 
 /* Bottom placement */
 .bcds-react-aria-Tooltip[data-placement="bottom"] {
-  margin-top: 9px;
+  margin-top: 10px;
 }
 .bcds-react-aria-Tooltip[data-placement="bottom"]
   > .bcds-react-aria-OverlayArrow {
-  margin-bottom: 6.5px;
+  margin-bottom: 4.5px;
 }
 
 /* Left placement */
@@ -70,8 +69,7 @@
 }
 .bcds-react-aria-Tooltip[data-placement="left"]
   > .bcds-react-aria-OverlayArrow {
-  margin-top: -2px;
-  margin-left: -5.5px;
+  margin-left: -5px;
 }
 .bcds-react-aria-Tooltip[data-placement="left"]
   > .bcds-react-aria-OverlayArrow


### PR DESCRIPTION
This pull request updates the Tooltip component to use the v3 design tokens. This component's size changes by moving to the new `label` font size, which required adjusting the margins of the arrow.

Before:
<img width="1840" alt="Screenshot 2024-03-25 at 9 05 11 AM" src="https://github.com/bcgov/design-system/assets/25143706/10a81a51-431b-4540-92ba-8a19d3e7d894">

After:
<img width="1840" alt="Screenshot 2024-03-25 at 9 05 17 AM" src="https://github.com/bcgov/design-system/assets/25143706/cd7eea2d-e77b-4979-8eb7-7df5602999f1">
