### PR TITLE
Update Header and Footer components to use v3 design tokens

### DIFF
--- a/packages/react-components/src/components/Footer/Footer.css
+++ b/packages/react-components/src/components/Footer/Footer.css
@@ -10,11 +10,9 @@
   flex-direction: column;
   align-items: center;
   justify-content: space-around;
-  border-top: var(--layout-border-width-large) solid
-    var(--surface-brand-gold-60);
-  border-bottom: var(--layout-border-width-large) solid
-    var(--surface-brand-gold-60);
-  background-color: var(--surface-brand-gray-110);
+  border-top: var(--layout-border-width-large) solid var(--theme-gold-60);
+  border-bottom: var(--layout-border-width-large) solid var(--theme-gold-60);
+  background-color: var(--theme-gray-110);
   padding: var(--layout-padding-xlarge);
 }
 
@@ -26,7 +24,7 @@
   align-items: center;
   justify-content: stretch;
   color: var(--typography-color-primary-invert);
-  font: var(--typography-regular-label);
+  font: var(--typography-regular-small-body);
   max-width: 1100px;
   width: 100%;
 }
@@ -43,7 +41,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: space-around;
-  background-color: var(--surface-background-light);
+  background-color: var(--surface-color-background-light-gray);
   padding: var(--layout-padding-xlarge);
 }
 
@@ -116,7 +114,7 @@
   > .bcds-footer--logo-links
   > .bcds-footer--logo
   > p {
-  font: var(--typography-regular-label);
+  font: var(--typography-regular-small-body);
   margin: var(--layout-margin-none);
 }
 
@@ -128,7 +126,7 @@
   > p
   > a {
   color: var(--typography-color-secondary);
-  font: var(--typography-regular-label);
+  font: var(--typography-regular-small-body);
   text-decoration: underline;
 }
 
@@ -169,7 +167,7 @@
   > .bcds-footer--links
   > .bcds-footer--links-title {
   display: block;
-  font: var(--typography-bold-label);
+  font: var(--typography-bold-small-body);
   margin-bottom: var(--layout-padding-medium);
   text-transform: uppercase;
 }
@@ -210,7 +208,7 @@
   > .bcds-footer--links
   > ul
   > li {
-  font: var(--typography-regular-label);
+  font: var(--typography-regular-small-body);
 }
 
 .bcds-footer
@@ -237,9 +235,9 @@
 }
 
 .bcds-footer > .bcds-footer--container > .bcds-footer--container-content > hr {
-  background-color: var(--surface-border-dark);
+  background-color: var(--surface-color-border-dark);
   border: var(--layout-border-width-none);
-  height: var(--surface-border-width-small);
+  height: var(--layout-border-width-small);
   margin: var(--layout-margin-none);
   width: 100%;
 }

--- a/packages/react-components/src/components/Header/Header.css
+++ b/packages/react-components/src/components/Header/Header.css
@@ -4,8 +4,8 @@
   flex-direction: row;
   align-items: center;
   justify-content: space-around;
-  background-color: var(--surface-background-white);
-  border-bottom-color: var(--surface-border-light);
+  background-color: var(--surface-color-background-white);
+  border-bottom-color: var(--surface-color-border-default);
   border-bottom-style: solid;
   border-bottom-width: var(--layout-border-width-small);
   min-height: 65px;
@@ -37,11 +37,11 @@
 
 .bcds-header > .bcds-header--container > ul.bcds-header--skiplinks li a,
 .bcds-header > .bcds-header--container > ul.bcds-header--skiplinks li button {
-  background-color: var(--surface-background-white);
+  background-color: var(--surface-color-background-white);
   box-sizing: border-box;
   color: var(--typography-color-link);
   font: var(--typography-regular-body);
-  margin-top: -17.5px; /* Center the link visually in a single line header */
+  margin-top: -17.5px; /* Center the link visually in a single line-height header */
   padding: var(--layout-padding-xsmall) var(--layout-padding-medium);
   position: absolute;
   margin-left: -100000px;
@@ -58,7 +58,7 @@
 }
 
 .bcds-header > .bcds-header--container > .bcds-header--line {
-  background-color: var(--surface-border-light);
+  background-color: var(--surface-color-border-default);
   width: 1px;
   height: 32px;
 }


### PR DESCRIPTION
This PR updates the Header and Footer React components to use the v3 design tokens. In both cases, there are no visual differences between the components, as we have specifically moved from using the `label` font size tokens to using `smallBody` font size tokens in the Footer, to preserve the existing font size choice.

Footer before:
<img width="1840" alt="Screenshot 2024-03-25 at 1 21 14 PM" src="https://github.com/bcgov/design-system/assets/25143706/b1d7f636-2f4b-422c-abe6-64c6a68fe96e">

Footer after
<img width="1840" alt="Screenshot 2024-03-25 at 1 21 16 PM" src="https://github.com/bcgov/design-system/assets/25143706/3e721af9-a2fc-445e-80b3-edea2243b3e5">

Header before
<img width="1840" alt="Screenshot 2024-03-25 at 1 21 33 PM" src="https://github.com/bcgov/design-system/assets/25143706/1b5019ec-1285-48d4-93e4-4b98b3fbcdc6">

Header after
<img width="1840" alt="Screenshot 2024-03-25 at 1 21 36 PM" src="https://github.com/bcgov/design-system/assets/25143706/31061098-c9a8-445e-8f4d-1d7f6ca91ebb">
