### PR TITLE
Update Select component to use smallBody font size token

### DIFF
--- a/packages/react-components/src/components/Select/Select.css
+++ b/packages/react-components/src/components/Select/Select.css
@@ -9,7 +9,7 @@
 
 /* Label above select input */
 .bcds-react-aria-Select--Label {
-  font: var(--typography-regular-label);
+  font: var(--typography-regular-small-body);
 }
 .bcds-react-aria-Select[data-disabled] > .bcds-react-aria-Select--Label {
   color: var(--typography-color-disabled);
@@ -94,7 +94,7 @@
 /* Header label within Section of multi-section Select */
 .bcds-react-aria-Select--Header {
   color: var(--typography-color-secondary);
-  font: var(--typography-regular-label);
+  font: var(--typography-regular-small-body);
   padding: var(--layout-margin-hair) var(--layout-margin-small);
 }
 
@@ -138,6 +138,6 @@
   color: var(--surface-color-primary-danger-button-default);
 }
 .bcds-react-aria-Select--ListBoxItem-Text-description {
-  font: var(--typography-regular-label);
+  font: var(--typography-regular-small-body);
   color: var(--typography-color-secondary);
 }


### PR DESCRIPTION
This PR builds on the work in #318. It refactors the `label` font size tokens to use `smallBody`. This makes the Select use the same font sizes as it did prior to using the v3 design tokens. After this PR, there is no visual differences between the existing released Select component and the new one using the v3 tokens.

Before:
<img width="1840" alt="Screenshot 2024-03-25 at 1 47 40 PM" src="https://github.com/bcgov/design-system/assets/25143706/c5a6e426-3e24-4e99-be75-b6c382de5ef5">

After:
<img width="1840" alt="Screenshot 2024-03-25 at 1 47 43 PM" src="https://github.com/bcgov/design-system/assets/25143706/4a4fd0ae-bb2b-4c6d-94d6-f210b3be76cb">

Before:
<img width="1840" alt="Screenshot 2024-03-25 at 1 48 13 PM" src="https://github.com/bcgov/design-system/assets/25143706/41040d25-187c-46cc-a692-ab192a0d6aa2">

After:
<img width="1840" alt="Screenshot 2024-03-25 at 1 48 15 PM" src="https://github.com/bcgov/design-system/assets/25143706/f7ab8aa3-b99c-4d98-aea6-d85b4d7ffae2">
