### PR TITLE
@bcgov/design-tokens v3.0.0

### DIFF
--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 3.0.0
+
+## Changed
+
+- (breaking) Many tokens have been renamed to bring the generated tokens in line with the intended token names from Figma
+- (breaking) `brand` color tokens renamed to `theme` to differentiate from [BC Visual Identity Program](https://www2.gov.bc.ca/gov/content?id=CCB4862101CD43C195FF395CAED00F95)
+- (breaking) `gold` color scale values reworked to be lighter
+- (breaking) `label` font size changed from 0.875rem to 0.75rem
+- (breaking) `surface` group tokens referring to colors now include component names (`button`, `form`, `menu`)
+- (breaking) `surface.border.light` color renamed to `surface.color.border.default`
+- (breaking) `borderRadius` moved from `surface` group to `layout` group
+- (breaking) File names for JavaScript tokens are renamed from `variables.js` to `index.js` for shorter import statements
+- Tokens in `layout` group use `rem` equivalent of previous `px` values where possible in Figma
+
+## Added
+
+- `primaryBlue` (equal to `blue100`) and `primaryGold` (equal to `gold100`) dedicated color tokens added
+- `smallBody` font size added at 0.875rem (the old `label` size)
+- `xxxdense` line height added
+- CommonJS variables are included in `cjs` and `cjs-prefixed` directories (with and without the `bcds` prefix) in addition to the existing ESM variables in `js` and `js-prefixed` directories
+- TypeScript type definitions are shipped with the JavaScript tokens
+- Heading level 6 `typography` group tokens added
+
+## Removed
+
+- (breaking) Removed `surface.size` (legacy testing tokens)
+- (breaking) Removed `surface.borderRadius` (these were duplicates from the `layout` group)
+
 ## 3.0.0-rc3
 
 ### Changed

--- a/packages/design-tokens/build/cjs-prefixed/index.d.ts
+++ b/packages/design-tokens/build/cjs-prefixed/index.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 export const bcdsSurfaceOpacity0 : number;

--- a/packages/design-tokens/build/cjs-prefixed/index.js
+++ b/packages/design-tokens/build/cjs-prefixed/index.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 module.exports = {

--- a/packages/design-tokens/build/cjs/index.d.ts
+++ b/packages/design-tokens/build/cjs/index.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 export const surfaceOpacity0 : number;

--- a/packages/design-tokens/build/cjs/index.js
+++ b/packages/design-tokens/build/cjs/index.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 module.exports = {

--- a/packages/design-tokens/build/css-prefixed/variables.css
+++ b/packages/design-tokens/build/css-prefixed/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 :root {

--- a/packages/design-tokens/build/css/variables.css
+++ b/packages/design-tokens/build/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 :root {

--- a/packages/design-tokens/build/js-prefixed/index.d.ts
+++ b/packages/design-tokens/build/js-prefixed/index.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 export const bcdsSurfaceOpacity0 : number;

--- a/packages/design-tokens/build/js-prefixed/index.js
+++ b/packages/design-tokens/build/js-prefixed/index.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 export const bcdsSurfaceOpacity0 = 0;

--- a/packages/design-tokens/build/js/index.d.ts
+++ b/packages/design-tokens/build/js/index.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 export const surfaceOpacity0 : number;

--- a/packages/design-tokens/build/js/index.js
+++ b/packages/design-tokens/build/js/index.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 export const surfaceOpacity0 = 0;

--- a/packages/design-tokens/dist/cjs-prefixed/index.d.ts
+++ b/packages/design-tokens/dist/cjs-prefixed/index.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 export const bcdsSurfaceOpacity0 : number;

--- a/packages/design-tokens/dist/cjs-prefixed/index.js
+++ b/packages/design-tokens/dist/cjs-prefixed/index.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 module.exports = {

--- a/packages/design-tokens/dist/cjs/index.d.ts
+++ b/packages/design-tokens/dist/cjs/index.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 export const surfaceOpacity0 : number;

--- a/packages/design-tokens/dist/cjs/index.js
+++ b/packages/design-tokens/dist/cjs/index.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 module.exports = {

--- a/packages/design-tokens/dist/css-prefixed/variables.css
+++ b/packages/design-tokens/dist/css-prefixed/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 :root {

--- a/packages/design-tokens/dist/css/variables.css
+++ b/packages/design-tokens/dist/css/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 :root {

--- a/packages/design-tokens/dist/js-prefixed/index.d.ts
+++ b/packages/design-tokens/dist/js-prefixed/index.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 export const bcdsSurfaceOpacity0 : number;

--- a/packages/design-tokens/dist/js-prefixed/index.js
+++ b/packages/design-tokens/dist/js-prefixed/index.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 export const bcdsSurfaceOpacity0 = 0;

--- a/packages/design-tokens/dist/js/index.d.ts
+++ b/packages/design-tokens/dist/js/index.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 export const surfaceOpacity0 : number;

--- a/packages/design-tokens/dist/js/index.js
+++ b/packages/design-tokens/dist/js/index.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 30 Apr 2024 20:16:22 GMT
+ * Generated on Wed, 01 May 2024 18:02:21 GMT
  */
 
 export const surfaceOpacity0 = 0;

--- a/packages/design-tokens/dist/package.json
+++ b/packages/design-tokens/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/design-tokens",
-  "version": "3.0.0-rc3",
+  "version": "3.0.0",
   "description": "Design tokens for B.C. Design System",
   "repository": {
     "type": "git",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-tokens",
-  "version": "3.0.0-rc3",
+  "version": "3.0.0",
   "description": "Transformation pipeline for design tokens for B.C. Design System",
   "scripts": {
     "build": "rm -rf build/cjs* && rm -rf build/css* && rm -rf build/js* && node build-output.js",


### PR DESCRIPTION
This moves the @bcgov/design-tokens package to v3.0.0. This release is [already published on npm here](https://www.npmjs.com/package/@bcgov/design-tokens/v/3.0.0), and there are no changes (aside from timestamp comments) from v3.0.0-rc3.