### PR TITLE
remove bad styling from Storybook theme

### DIFF
--- a/packages/react-components/.storybook/bcdsTheme.js
+++ b/packages/react-components/.storybook/bcdsTheme.js
@@ -18,10 +18,6 @@ export default create({
   appBorderColor: tokens.surfaceColorBorderDefault,
   appBorderRadius: tokens.layoutBorderRadiusMedium,
 
-  // Buttons
-  buttonBg: tokens.surfaceColorPrimaryButtonDefault,
-  buttonBorder: tokens.surfaceColorBorderDefault,
-
   // Text colors
   textColor: tokens.typographyColorPrimary,
   textInverseColor: tokens.typographyColorPrimaryInvert,


### PR DESCRIPTION
This change removes two custom styling rules from the `bcdsTheme`, because they break part of the Storybook UI by making buttons in the 'Controls' sidebar of story view impossible to read.