### PR TITLE
Add :latest tag to Storybook docker build script

### DIFF
--- a/.github/workflows/build_storybook.yaml
+++ b/.github/workflows/build_storybook.yaml
@@ -27,7 +27,7 @@ jobs:
           driver-opts: network=host
 
       - name: Build image with docker build
-        run: docker build ./packages/react-components/ -f ./packages/react-components/Dockerfile.storybook
+        run: docker build ./packages/react-components/ -f ./packages/react-components/Dockerfile.storybook -t design-system-react-components-storybook:latest
 
       - name: Login to OpenShift Silver image registry
         uses: docker/login-action@v3


### PR DESCRIPTION
This updates the `build_storybook.yaml` GitHub Actions workflow file to add a `:latest` tag to the Storybook image after it is built. This should fix [the broken action](https://github.com/bcgov/design-system/actions/runs/9130932693/job/25109002772) that is throwing this error:

```
Run docker tag design-system-react-components-storybook:latest image-registry.apps.silver.devops.gov.bc.ca/***-tools/design-system-react-components-storybook:develop
  docker tag design-system-react-components-storybook:latest image-registry.apps.silver.devops.gov.bc.ca/***-tools/design-system-react-components-storybook:develop
  docker push image-registry.apps.silver.devops.gov.bc.ca/***-tools/design-system-react-components-storybook --all-tags
  shell: /usr/bin/bash -e {0}
Error response from daemon: No such image: design-system-react-components-storybook:latest
Error: Process completed with exit code 1.
```

<img width="1840" alt="Screenshot of GitHub Action showing broken tag step" src="https://github.com/bcgov/design-system/assets/25143706/6914ecd5-b7c5-4bc1-b9aa-cf6a9e490a51">
