### PR TITLE
Update Storybook Introduction story with documentation hub link

### DIFF
--- a/packages/react-components/src/stories/Introduction.mdx
+++ b/packages/react-components/src/stories/Introduction.mdx
@@ -4,7 +4,7 @@ import { Meta } from "@storybook/blocks";
 
 # B.C. Design System React Components
 
-This Storybook instance holds React component stories for the B.C. Design System. Open the Components menu on the left to explore the components that are currently available.
+This Storybook instance holds React component stories for the [B.C. Design System](https://gov.bc.ca/designsystem). Open the Components menu on the left to explore the components that are currently available.
 
 Questions? Please email the <a href="mailto:DesignSystem@gov.bc.ca">GDX OSS Design Team</a>.
 


### PR DESCRIPTION
This PR adds a link to the [gov.bc.ca documentation hub](https://gov.bc.ca/designsystem) to the Storybook Introduction story:

![Storybook Introduction screenshot](https://github.com/bcgov/design-system/assets/25143706/c369e95f-2cf4-4293-8574-3338ac8eb820)
