### PR TITLE
Add GitHub Actions workflow job for building and pushing Vite app

### DIFF
--- a/.github/workflows/build_react_component_library_apps.yaml
+++ b/.github/workflows/build_react_component_library_apps.yaml
@@ -40,3 +40,31 @@ jobs:
         run: |
           docker tag design-system-react-components-storybook:latest image-registry.apps.silver.devops.gov.bc.ca/${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE }}-tools/design-system-react-components-storybook:develop
           docker push image-registry.apps.silver.devops.gov.bc.ca/${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE }}-tools/design-system-react-components-storybook --all-tags
+
+  vite-build-and-push:
+    name: Vite build and push
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
+
+      - name: Build image with docker build
+        run: docker build ./packages/react-components/ -f ./packages/react-components/Dockerfile.vite -t design-system-react-components-vite:latest
+
+      - name: Login to OpenShift Silver image registry
+        uses: docker/login-action@v3
+        with:
+          registry: image-registry.apps.silver.devops.gov.bc.ca
+          username: ${{ secrets.OPENSHIFT_SILVER_SERVICEACCOUNT_USERNAME }}
+          password: ${{ secrets.OPENSHIFT_SILVER_SERVICEACCOUNT_PASSWORD }}
+
+      - name: Tag and push Docker image
+        run: |
+          docker tag design-system-react-components-vite:latest image-registry.apps.silver.devops.gov.bc.ca/${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE }}-tools/design-system-react-components-vite:develop
+          docker push image-registry.apps.silver.devops.gov.bc.ca/${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE }}-tools/design-system-react-components-vite --all-tags


### PR DESCRIPTION
This PR adds a new GitHub Action workflow job `vite-build-and-push` that uses the React component library's `Dockerfile.vite` to do a build of the Vite kitchen sink application, pushing the resultant image to OpenShift. I've added it to the existing file with the Storybook build job because it will use the same triggers. These jobs are not dependent on one another to succeed, and [should proceed in parallel by default](https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow).