### PR TITLE
GitHub commit link in Storybook build

### DIFF
--- a/.github/workflows/build_react_component_library_apps.yaml
+++ b/.github/workflows/build_react_component_library_apps.yaml
@@ -27,7 +27,7 @@ jobs:
           driver-opts: network=host
 
       - name: Build image with docker build
-        run: docker build ./packages/react-components/ -f ./packages/react-components/Dockerfile.storybook -t design-system-react-components-storybook:latest
+        run: docker build ./packages/react-components/ -f ./packages/react-components/Dockerfile.storybook -t design-system-react-components-storybook:latest --build-arg GITHUB_SHA=${{ env.GITHUB_SHA }}
 
       - name: Login to OpenShift Silver image registry
         uses: docker/login-action@v3

--- a/packages/react-components/Dockerfile.storybook
+++ b/packages/react-components/Dockerfile.storybook
@@ -4,6 +4,8 @@
 # Build stage
 # -----------
 FROM node:lts-alpine as build-stage
+ARG GITHUB_SHA
+ENV GITHUB_SHA=$GITHUB_SHA
 
 # Copy package.json and package-lock.json
 WORKDIR /app
@@ -22,7 +24,7 @@ COPY .storybook ./.storybook
 COPY storybook-public ./storybook-public
 
 # Run Storybook build script, which places built files in /app/storybook-static
-RUN npm run storybook-build
+RUN STORYBOOK_GITHUB_SHA=$GITHUB_SHA npm run storybook-build
 
 # -----------
 # Serve stage

--- a/packages/react-components/src/stories/Introduction.mdx
+++ b/packages/react-components/src/stories/Introduction.mdx
@@ -1,5 +1,18 @@
 import { Meta } from "@storybook/blocks";
 
+import packageJson from "../../package.json";
+
+export const sha = import.meta.env?.STORYBOOK_GITHUB_SHA
+  ? import.meta.env.STORYBOOK_GITHUB_SHA.substring(0, 7)
+  : null;
+export const url = `https://github.com/bcgov/design-system/commit/${import.meta.env.STORYBOOK_GITHUB_SHA}`;
+export const link =
+  sha && url ? (
+    <>
+      , SHA: <a href={url}>{sha}</a>
+    </>
+  ) : null;
+
 <Meta title="Introduction" />
 
 # B.C. Design System React Components
@@ -15,3 +28,7 @@ This library is available from npm as [`@bcgov/design-system-react-components`](
 ## Design tokens
 
 This library uses [`@bcgov/design-tokens`](https://www.npmjs.com/package/@bcgov/design-tokens) for styling. Learn more about our design tokens in our [B.C. Design Tokens Figma community file](https://www.figma.com/community/file/1326994583954765832).
+
+## Version
+
+This Storybook instance was built from v{packageJson.version}{link}.


### PR DESCRIPTION
This PR uses the [`GITHUB_SHA` workflow environment variable](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) to display a link within the React component library Storybook that points back to the commit that kicked off the Storybook build. This allows visitors to our Storybook instances to understand which version of the React component library code the Storybook documentation refers to. The version of the package from `/package/react-components/package.json` is also shown.

Example Storybook screenshot when the GitHub SHA variable is available:
<img width="1840" alt="Storybook after a build" src="https://github.com/bcgov/design-system/assets/25143706/06e3849d-ea70-48d8-b1c8-55894eee5047">

Example Storybook screenshot when the GitHub SHA isn't present, like in local development:
<img width="1840" alt="Storybook in local development" src="https://github.com/bcgov/design-system/assets/25143706/10a91431-f180-409d-bc12-b1487567fdd9">
