### PR TITLE
Use github.sha instead of pull request reference in GitHub Action for building React apps

### DIFF
--- a/.github/workflows/build_react_component_library_apps.yaml
+++ b/.github/workflows/build_react_component_library_apps.yaml
@@ -27,7 +27,7 @@ jobs:
           driver-opts: network=host
 
       - name: Build image with docker build
-        run: docker build ./packages/react-components/ -f ./packages/react-components/Dockerfile.storybook -t design-system-react-components-storybook:latest --build-arg GITHUB_SHA=${{ github.event.pull_request.head.sha }}
+        run: docker build ./packages/react-components/ -f ./packages/react-components/Dockerfile.storybook -t design-system-react-components-storybook:latest --build-arg GITHUB_SHA=${{ github.sha }}
 
       - name: Login to OpenShift Silver image registry
         uses: docker/login-action@v3


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow that builds our React applications (Storybook and the Vite kitchen sink app).

In the `Build image with docker build` step of this workflow, I am trying to reference the GitHub SHA of the latest commit used to build the Storybook application, so that it will appear in the Storybook app for the developer's reference. See #356 for the intended function.

I find that the environment variable representing the SHA isn't showing up in the Docker build step. Here is an example run of the workflow where the job completes, but without the environment variable showing up as expected in the [deployed app](https://design-system-react-components-storybook-ed91fb-dev.apps.silver.devops.gov.bc.ca/?path=/docs/introduction--docs): https://github.com/bcgov/design-system/actions/runs/9216225746/job/25356083436

This PR attempts to fix the issue by removing the "pull request" reference from the environment variable, instead referencing `github.sha` directly.