### PR TITLE
Add working-directory to test workflow steps that need package.json

### DIFF
--- a/.github/workflows/test_react_component_library.yaml
+++ b/.github/workflows/test_react_component_library.yaml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Install dependencies
         run: npm install
+        working-directory: ./packages/react-components
 
       - name: Run test suite with npm script
         run: npm run test:ci
+        working-directory: ./packages/react-components

--- a/.github/workflows/test_react_component_library.yaml
+++ b/.github/workflows/test_react_component_library.yaml
@@ -22,6 +22,7 @@ jobs:
 
       - name: Read .nvmrc
         run: echo "::set-output name=NVMRC::$(cat .nvmrc)"
+        working-directory: ./packages/react-components
         id: nvm
 
       - name: Set up Node.js


### PR DESCRIPTION
This adds [the `working-directory` keyword](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsworking-directory) to the React components test suite workflow for the steps that require `npm` to be able to access `package.json`. This is to fix [this failing workflow](https://github.com/bcgov/design-system/actions/runs/9277021771):

<img width="1840" alt="GitHub Actions workflow screenshot" src="https://github.com/bcgov/design-system/assets/25143706/0fba5f4c-82ef-4723-8b51-029d6bfbfac6">