### PR TITLE
Use environment variable instead of deprecated set-output to set Node version

### DIFF
--- a/.github/workflows/test_react_component_library.yaml
+++ b/.github/workflows/test_react_component_library.yaml
@@ -21,14 +21,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Read .nvmrc
-        run: echo "::set-output name=NVMRC::$(cat .nvmrc)"
+        run: echo "GITHUB_NVMRC_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV
         working-directory: ./packages/react-components
-        id: nvm
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+          node-version: $GITHUB_NVMRC_VERSION
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
This updates the React components test suite workflow file from #360 to remove the use of `set-output` which is [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) as seen in this notice in the Actions tab:

<img width="1722" alt="Workflow run showing set-output deprecation" src="https://github.com/bcgov/design-system/assets/25143706/8522da00-d167-403c-a5f6-85343dea97cc">
