### PR TITLE
Fix environment variable syntax in React component test workflow

### DIFF
--- a/.github/workflows/test_react_component_library.yaml
+++ b/.github/workflows/test_react_component_library.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: $GITHUB_NVMRC_VERSION
+          node-version: ${{ env.GITHUB_NVMRC_VERSION }}
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
This PR attempts to fix this failing workflow run: https://github.com/bcgov/design-system/actions/runs/9277818218/job/25527710711

Here, I'm keeping the syntax from #363 to set the variable, but I'm accessing it in a later step using the `${{ env.<VARIABLE> }}` syntax.

<img width="1840" alt="Failing workflow run screenshot" src="https://github.com/bcgov/design-system/assets/25143706/98d3d959-3049-4f1a-8fc8-de290bb26fa2">
