### PR TITLE
override automated test for aria-hidden-focus in Select component

### DIFF
--- a/packages/react-components/src/stories/Select.stories.tsx
+++ b/packages/react-components/src/stories/Select.stories.tsx
@@ -7,6 +7,13 @@ const meta = {
   component: Select,
   parameters: {
     layout: "centered",
+    a11y: {
+      config: {
+        // overrides automated accessibility testing for aria-hidden-focus to suppress a known false positive
+        // see https://react-spectrum.adobe.com/react-aria/Select.html#false-positives for more information
+        rules: [{ id: 'aria-hidden-focus', enabled: false }],
+      }
+    }
   },
   argTypes: {
     size: {


### PR DESCRIPTION
This change overrides automated accessibility testing for `aria-hidden-focus` in the Select component in Storybook, in order to suppress a known false positive (see #367) in the [storybook-addon-a11y](https://storybook.js.org/addons/@storybook/addon-a11y) reporting.

False positive violation no longer shown in accessibility panel:

<img width="1680" alt="Screenshot 2024-05-30 at 11 07 02" src="https://github.com/bcgov/design-system/assets/135075821/333f6522-f2e6-498d-b64c-a424f6121cf1">