### PR TITLE
add changelog to dockerfile to fix broken storybook build

### DIFF
--- a/packages/react-components/Dockerfile.storybook
+++ b/packages/react-components/Dockerfile.storybook
@@ -19,6 +19,7 @@ RUN npm config list
 RUN npm install
 
 # Copy required files
+COPY CHANGELOG.md ./CHANGELOG.md
 COPY src ./src
 COPY .storybook ./.storybook
 COPY storybook-public ./storybook-public


### PR DESCRIPTION
Fixing broken Storybook build resulting from #369.

Adds CHANGELOG.md to Dockerfile to fix a rollup error. 