### PR TITLE
Update service account references in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build_react_component_library_apps.yaml
+++ b/.github/workflows/build_react_component_library_apps.yaml
@@ -38,7 +38,7 @@ jobs:
           # Ex: For `system:serviceaccount:<name space>:<service account name>`,
           # just use `<service account name>`.
           username: ${{ secrets.OPENSHIFT_SILVER_SERVICEACCOUNT_USERNAME }}
-          password: ${{ secrets.OPENSHIFT_SILVER_SERVICEACCOUNT_PASSWORD }}
+          password: ${{ secrets.OPENSHIFT_SILVER_SERVICEACCOUNT_TOKEN }}
 
       - name: Tag and push Docker image
         run: |
@@ -66,7 +66,7 @@ jobs:
         with:
           registry: image-registry.apps.silver.devops.gov.bc.ca
           username: ${{ secrets.OPENSHIFT_SILVER_SERVICEACCOUNT_USERNAME }}
-          password: ${{ secrets.OPENSHIFT_SILVER_SERVICEACCOUNT_PASSWORD }}
+          password: ${{ secrets.OPENSHIFT_SILVER_SERVICEACCOUNT_TOKEN }}
 
       - name: Tag and push Docker image
         run: |

--- a/.github/workflows/build_react_component_library_apps.yaml
+++ b/.github/workflows/build_react_component_library_apps.yaml
@@ -33,6 +33,10 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: image-registry.apps.silver.devops.gov.bc.ca
+          # This refers to the serviceaccount name alone, not the fully qualified
+          # value that comes out of `oc whoami` when logged in as the SA.
+          # Ex: For `system:serviceaccount:<name space>:<service account name>`,
+          # just use `<service account name>`.
           username: ${{ secrets.OPENSHIFT_SILVER_SERVICEACCOUNT_USERNAME }}
           password: ${{ secrets.OPENSHIFT_SILVER_SERVICEACCOUNT_PASSWORD }}
 


### PR DESCRIPTION
This PR adds a comment to the variable for the OpenShift service account in the React components library GitHub Actions workflow file. It also renames the `_PASSWORD` variable to `_TOKEN` for clarity, since OpenShift doesn't use the term "password" in this context. I've already added the new variable to this repository, so I expect the build to succeed when this is merged.