### PR TITLE
Remove curly braces and use single quotes in workflow conditional expressions

### DIFF
--- a/.github/workflows/build_react_component_library_apps.yaml
+++ b/.github/workflows/build_react_component_library_apps.yaml
@@ -16,7 +16,7 @@ jobs:
   storybook-build-and-push:
     name: Storybook build and push
     runs-on: ubuntu-latest
-    if: ${{ github.repository == "bcgov/design-system" }}
+    if: github.repository == 'bcgov/design-system'
 
     steps:
       - name: Checkout code
@@ -49,7 +49,7 @@ jobs:
   vite-build-and-push:
     name: Vite build and push
     runs-on: ubuntu-latest
-    if: ${{ github.repository == "bcgov/design-system" }}
+    if: github.repository == 'bcgov/design-system'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
This attempts to fix the broken build: https://github.com/bcgov/design-system/actions/runs/9371733967

<img width="1840" alt="Broken GitHub Actions workflow" src="https://github.com/bcgov/design-system/assets/25143706/1b033ca0-7dd9-4566-916d-8860e1eaba18">
