### PR TITLE
Make Button accessibility tests pass in Storybook

### DIFF
--- a/packages/react-components/src/stories/Button.mdx
+++ b/packages/react-components/src/stories/Button.mdx
@@ -43,6 +43,6 @@ Use the `danger` boolean prop to mark a button that is destructive (delete actio
 
 Icons can be dropped into the button as React children. You can also get an icon-only square button (fixed width) with the `isIconButton` boolean.
 
-<Canvas of={ButtonStories.PlaceholderIconButton} />
+<Canvas of={ButtonStories.Icon} />
 <Canvas of={ButtonStories.RightIcon} />
 <Canvas of={ButtonStories.LeftIcon} />

--- a/packages/react-components/src/stories/Button.stories.tsx
+++ b/packages/react-components/src/stories/Button.stories.tsx
@@ -177,13 +177,3 @@ export const Small: Story = {
     size: "small",
   },
 };
-
-export const PlaceholderIconButton: Story = {
-  ...ButtonTemplate,
-  ...Icon,
-  args: {
-    isIconButton: true,
-    children: <>{iconPlaceholder}</>,
-    size: "medium",
-  },
-};

--- a/packages/react-components/src/stories/Button.stories.tsx
+++ b/packages/react-components/src/stories/Button.stories.tsx
@@ -84,6 +84,8 @@ const iconPlaceholder = (
 export const Icon: Story = {
   ...ButtonTemplate,
   args: {
+    "aria-label":
+      "Icon-only buttons need discernible text labels for accessibility",
     children: iconPlaceholder,
     isIconButton: true,
   },


### PR DESCRIPTION
This PR builds on #383 to fix the failing Storybook accessibility tests for the Button component.

Prior to this PR, the `Icon` and `PlaceholderIconButton` stories violate the test for "Buttons must have discernible text":

![Storybook screenshot showing Icon story in Button component failing a test](https://github.com/bcgov/design-system/assets/25143706/0f0657d6-9141-4292-bedf-9cb7cf94c2e5)

This is mirrored in our `test-storybook` script output:

<img width="656" alt="2 tests failing" src="https://github.com/bcgov/design-system/assets/25143706/84a35bff-745d-4d80-b0c6-e9c0522b2cbe">

<img width="1036" alt="Specific button tests failing" src="https://github.com/bcgov/design-system/assets/25143706/560dec3c-85ce-4c01-8f1a-d6495188f4af">

I've fixed the failing test in the Icon story by adding an explicit `aria-label` 9f3682726bb35d2a3302e3ebf3a190960bdb7320.

This pull request also removes `ButtonStories.PlaceholderIconButton`, which is a duplicate of `ButtonStories.Icon` 0ff65a48a4c4b1a646f9639e04e803778d8cb3d2. I've replaced the instance of `PlaceholderIconButton` in the Button documentation file in 33c50bd4f89b391c4c1969e3ed854a70d3e796a4.

We should aim to make this accessibility requirement super clear in our Button documentation (like in #378).

After this PR is merged, our Storybook tests will be 100% passing in the command line, with one failure shown in the app as detailed in #368.
