### PR TITLE
Add Playwright test run job to React component library test workflow

### DIFF
--- a/.github/workflows/test_react_component_library.yaml
+++ b/.github/workflows/test_react_component_library.yaml
@@ -1,4 +1,4 @@
-name: Run test suite for React component library
+name: Test React components library
 
 on:
   pull_request:
@@ -12,8 +12,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  react-components-test:
-    name: Test suite run
+  jest-unit-tests:
+    name: Jest unit tests
     runs-on: ubuntu-latest
 
     steps:
@@ -35,4 +35,40 @@ jobs:
 
       - name: Run test suite with npm script
         run: npm run test:ci
+        working-directory: ./packages/react-components
+
+  playwright-accessibility-tests:
+    name: Playwright accessibility tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Read .nvmrc
+        run: echo "GITHUB_NVMRC_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV
+        working-directory: ./packages/react-components
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.GITHUB_NVMRC_VERSION }}
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: ./packages/react-components
+
+      - name: Install Playwright
+        run: npx playwright install --with-deps
+        working-directory: ./packages/react-components
+
+      - name: Build Storybook
+        run: npm run storybook-build
+        working-directory: ./packages/react-components
+
+      - name: Serve Storybook and run tests
+        run: |
+          npx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
+            "npx http-server storybook-static --port 6006 --silent" \
+            "npx wait-on tcp:6006 && npm run test-storybook:ci"
         working-directory: ./packages/react-components


### PR DESCRIPTION
This PR adds a new job to the existing React component library test GitHub Actions workflow file which runs the Playwright/Axe accessibility tests from #383. I followed the example in the [How to automate UI tests with Github Actions](https://storybook.js.org/tutorials/ui-testing-handbook/react/en/automate/) article from Storybook. Because it's in the same workflow file, it will run on the same trigger (currently, when a new pull request is created). I've confirmed that the script in the `Serve Storybook and run tests` step runs as expected locally, but this may need adjustment after a run in GitHub Actions. 

<img width="1092" alt="Local command line run of npx concurrently script" src="https://github.com/bcgov/design-system/assets/25143706/7632ebfb-9a5b-4742-9166-ac5b6ebca6cf">
