### PR TITLE
Select/dropdown - improve error handling and focus state

### DIFF
--- a/packages/react-components/src/components/Select/Select.css
+++ b/packages/react-components/src/components/Select/Select.css
@@ -17,12 +17,6 @@
   color: var(--typography-color-disabled);
 }
 
-/* "(optional)" text after Label*/
-.bcds-react-aria-Select--Label > .optional {
-  padding: var(--layout-padding-none) var(--layout-padding-xsmall);
-  color: var(--typography-color-secondary);
-}
-
 /* Error message */
 .bcds-react-aria-Select--Error {
   font: var(--typography-regular-small-body);

--- a/packages/react-components/src/components/Select/Select.css
+++ b/packages/react-components/src/components/Select/Select.css
@@ -9,6 +9,8 @@
 
 /* Label above select input */
 .bcds-react-aria-Select--Label {
+  display: flex;
+  padding: var(--layout-padding-small) var(--layout-padding-none);
   color: var(--typography-color-secondary);
   font: var(--typography-regular-small-body);
 }
@@ -18,6 +20,7 @@
 
 /* "(optional)" text after Label*/
 .bcds-react-aria-Select--Label > .optional {
+  padding: var(--layout-padding-none) var(--layout-padding-xsmall);
   color: var(--typography-color-secondary);
 }
 

--- a/packages/react-components/src/components/Select/Select.css
+++ b/packages/react-components/src/components/Select/Select.css
@@ -21,6 +21,12 @@
   color: var(--typography-color-secondary);
 }
 
+/* Error message */
+.bcds-react-aria-Select--Error {
+  font: var(--typography-regular-body);
+  color: var(--typography-color-danger);
+}
+
 /* Select input equivalent */
 .bcds-react-aria-Select--Button {
   background-color: var(--surface-color-forms-default);

--- a/packages/react-components/src/components/Select/Select.css
+++ b/packages/react-components/src/components/Select/Select.css
@@ -26,6 +26,8 @@
 
 /* Error message */
 .bcds-react-aria-Select--Error {
+  display: flex;
+  padding: var(--layout-padding-small) var(--layout-padding-none);
   font: var(--typography-regular-small-body);
   color: var(--typography-color-danger);
 }

--- a/packages/react-components/src/components/Select/Select.css
+++ b/packages/react-components/src/components/Select/Select.css
@@ -8,10 +8,9 @@
 
 /* Label above select input */
 .bcds-react-aria-Select--Label {
-  display: flex;
   color: var(--typography-color-secondary);
   font: var(--typography-regular-small-body);
-  padding: var(--layout-padding-small) var(--layout-padding-none);
+  gap: var(--layout-margin-xsmall);
 }
 .bcds-react-aria-Select[data-disabled] > .bcds-react-aria-Select--Label {
   color: var(--typography-color-disabled);
@@ -19,13 +18,12 @@
 
 /* "(optional)" text after Label*/
 .bcds-react-aria-Select--Label > .optional {
-  color: var(--typography-color-primary);
-  padding: var(--layout-padding-none) var(--layout-padding-xsmall);
+  color: var(--typography-color-secondary);
 }
 
 /* Error message */
 .bcds-react-aria-Select--Error {
-  font: var(--typography-regular-small-body);
+  font: var(--typography-regular-body);
   color: var(--typography-color-danger);
 }
 
@@ -38,6 +36,9 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: var(--layout-margin-small);
+  padding: var(--layout-padding-small) 12px;
+  margin: var(--layout-margin-xsmall) var(--layout-margin-none);
 }
 .bcds-react-aria-Select--Button.invalid {
   border-color: var(--support-border-color-danger);

--- a/packages/react-components/src/components/Select/Select.css
+++ b/packages/react-components/src/components/Select/Select.css
@@ -1,6 +1,7 @@
 .bcds-react-aria-Select {
   display: inline-flex;
   flex-direction: column;
+  gap: var(--layout-margin-xsmall);
   /* Hacks for `stretch`: https://caniuse.com/mdn-css_properties_max-width_stretch */
   max-width: -moz-available;
   max-width: -webkit-fill-available;
@@ -10,7 +11,6 @@
 .bcds-react-aria-Select--Label {
   color: var(--typography-color-secondary);
   font: var(--typography-regular-small-body);
-  gap: var(--layout-margin-xsmall);
 }
 .bcds-react-aria-Select[data-disabled] > .bcds-react-aria-Select--Label {
   color: var(--typography-color-disabled);
@@ -35,10 +35,9 @@
   cursor: pointer;
   display: flex;
   justify-content: space-between;
-  align-items: center;
   gap: var(--layout-margin-small);
-  padding: var(--layout-padding-small) 12px;
-  margin: var(--layout-margin-xsmall) var(--layout-margin-none);
+  align-items: center;
+  padding: 0 12px;
 }
 .bcds-react-aria-Select--Button.invalid {
   border-color: var(--support-border-color-danger);

--- a/packages/react-components/src/components/Select/Select.css
+++ b/packages/react-components/src/components/Select/Select.css
@@ -89,7 +89,7 @@
   box-shadow: var(--surface-shadow-medium);
   box-sizing: border-box;
   overflow-y: auto;
-  padding: var(--layout-margin-hair) var(--layout-margin-xsmall);
+  padding: var(--layout-margin-hair) var(--layout-padding-xsmall);
   width: var(
     --trigger-width
   ); /* Variable provided by Select component https://react-spectrum.adobe.com/react-aria/Select.html#popover-1 */
@@ -107,7 +107,7 @@
 .bcds-react-aria-Select--Header {
   color: var(--typography-color-secondary);
   font: var(--typography-regular-small-body);
-  padding: var(--layout-margin-hair) var(--layout-margin-small);
+  padding: var(--layout-margin-hair) var(--layout-padding-small);
 }
 
 /* ListBox option item */

--- a/packages/react-components/src/components/Select/Select.css
+++ b/packages/react-components/src/components/Select/Select.css
@@ -8,9 +8,10 @@
 
 /* Label above select input */
 .bcds-react-aria-Select--Label {
+  display: flex;
   color: var(--typography-color-secondary);
   font: var(--typography-regular-small-body);
-  gap: var(--layout-margin-xsmall);
+  padding: var(--layout-padding-small) var(--layout-padding-none);
 }
 .bcds-react-aria-Select[data-disabled] > .bcds-react-aria-Select--Label {
   color: var(--typography-color-disabled);
@@ -18,12 +19,13 @@
 
 /* "(optional)" text after Label*/
 .bcds-react-aria-Select--Label > .optional {
-  color: var(--typography-color-secondary);
+  color: var(--typography-color-primary);
+  padding: var(--layout-padding-none) var(--layout-padding-xsmall);
 }
 
 /* Error message */
 .bcds-react-aria-Select--Error {
-  font: var(--typography-regular-body);
+  font: var(--typography-regular-small-body);
   color: var(--typography-color-danger);
 }
 
@@ -36,9 +38,6 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: var(--layout-margin-small);
-  padding: var(--layout-padding-small) 12px;
-  margin: var(--layout-margin-xsmall) var(--layout-margin-none);
 }
 .bcds-react-aria-Select--Button.invalid {
   border-color: var(--support-border-color-danger);

--- a/packages/react-components/src/components/Select/Select.css
+++ b/packages/react-components/src/components/Select/Select.css
@@ -1,7 +1,6 @@
 .bcds-react-aria-Select {
   display: inline-flex;
   flex-direction: column;
-  gap: var(--layout-margin-xsmall);
   /* Hacks for `stretch`: https://caniuse.com/mdn-css_properties_max-width_stretch */
   max-width: -moz-available;
   max-width: -webkit-fill-available;
@@ -11,6 +10,7 @@
 .bcds-react-aria-Select--Label {
   color: var(--typography-color-secondary);
   font: var(--typography-regular-small-body);
+  gap: var(--layout-margin-xsmall);
 }
 .bcds-react-aria-Select[data-disabled] > .bcds-react-aria-Select--Label {
   color: var(--typography-color-disabled);
@@ -35,9 +35,10 @@
   cursor: pointer;
   display: flex;
   justify-content: space-between;
-  gap: var(--layout-margin-small);
   align-items: center;
-  padding: 0 12px;
+  gap: var(--layout-margin-small);
+  padding: var(--layout-padding-small) 12px;
+  margin: var(--layout-margin-xsmall) var(--layout-margin-none);
 }
 .bcds-react-aria-Select--Button.invalid {
   border-color: var(--support-border-color-danger);

--- a/packages/react-components/src/components/Select/Select.css
+++ b/packages/react-components/src/components/Select/Select.css
@@ -54,7 +54,9 @@
 }
 .bcds-react-aria-Select--Button[data-focused] {
   border-color: var(--surface-color-border-active);
-  outline: none;
+  outline: solid var(--layout-border-width-medium)
+    var(--surface-color-border-active);
+  outline-offset: var(--layout-margin-hair);
 }
 .bcds-react-aria-Select--Button[data-pressed] {
   border-color: var(--surface-color-border-active);

--- a/packages/react-components/src/components/Select/Select.css
+++ b/packages/react-components/src/components/Select/Select.css
@@ -1,7 +1,8 @@
 .bcds-react-aria-Select {
-  display: inline-flex;
+  display: flex;
   flex-direction: column;
-  gap: var(--layout-margin-xsmall);
+  gap: var(--layout-margin-small);
+  align-items: flex-start;
   /* Hacks for `stretch`: https://caniuse.com/mdn-css_properties_max-width_stretch */
   max-width: -moz-available;
   max-width: -webkit-fill-available;
@@ -9,8 +10,6 @@
 
 /* Label above select input */
 .bcds-react-aria-Select--Label {
-  display: flex;
-  padding: var(--layout-padding-small) var(--layout-padding-none);
   color: var(--typography-color-secondary);
   font: var(--typography-regular-small-body);
 }
@@ -26,8 +25,6 @@
 
 /* Error message */
 .bcds-react-aria-Select--Error {
-  display: flex;
-  padding: var(--layout-padding-small) var(--layout-padding-none);
   font: var(--typography-regular-small-body);
   color: var(--typography-color-danger);
 }

--- a/packages/react-components/src/components/Select/Select.css
+++ b/packages/react-components/src/components/Select/Select.css
@@ -26,7 +26,7 @@
 
 /* Error message */
 .bcds-react-aria-Select--Error {
-  font: var(--typography-regular-body);
+  font: var(--typography-regular-small-body);
   color: var(--typography-color-danger);
 }
 

--- a/packages/react-components/src/components/Select/Select.tsx
+++ b/packages/react-components/src/components/Select/Select.tsx
@@ -119,7 +119,7 @@ export default function Select<T extends object>({
   ...props
 }: SelectProps<T>) {
   return (
-    <ReactAriaSelect {...props}>
+    <ReactAriaSelect {...props} className="bcds-react-aria-Select">
       {({ isOpen, isRequired, isInvalid }) => (
         <>
           {label && (

--- a/packages/react-components/src/components/Select/Select.tsx
+++ b/packages/react-components/src/components/Select/Select.tsx
@@ -90,6 +90,24 @@ function ChevronUp() {
   );
 }
 
+/* Icon displayed when input is in invalid state */
+const iconError = (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 20 20"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g id="20px/Error icon">
+      <path
+        id="Icon"
+        d="M17.835 15.0312C18.335 15.9062 17.71 17 16.6787 17H3.33499C2.30374 17 1.67874 15.9062 2.14749 15.0312L8.83499 3.65625C9.11624 3.21875 9.55373 3 10.0225 3C10.46 3 10.8975 3.21875 11.1787 3.65625L17.835 15.0312ZM3.64749 15.5H16.3663L9.99123 4.65625L3.64749 15.5ZM10.0225 12.5625C10.5537 12.5625 10.9912 13 10.9912 13.5312C10.9912 14.0625 10.5537 14.5 10.0225 14.5C9.45998 14.5 9.02249 14.0625 9.02249 13.5312C9.02249 13 9.45998 12.5625 10.0225 12.5625ZM9.27249 7.75C9.27249 7.34375 9.58498 7 10.0225 7C10.4287 7 10.7725 7.34375 10.7725 7.75V10.75C10.7725 11.1875 10.4287 11.5 10.0225 11.5C9.58498 11.5 9.27249 11.1875 9.27249 10.75V7.75Z"
+        fill="var(--icons-color-danger)"
+      />
+    </g>
+  </svg>
+);
+
 /** Select displays a collapsible list of options and allows a user to select one of them. */
 export default function Select<T extends object>({
   items,
@@ -128,6 +146,7 @@ export default function Select<T extends object>({
                 return "Select an item";
               }}
             />
+            {isInvalid && iconError}
             {isOpen ? <ChevronUp /> : <ChevronDown />}
           </Button>
           <FieldError className="bcds-react-aria-Select--Error">

--- a/packages/react-components/src/components/Select/Select.tsx
+++ b/packages/react-components/src/components/Select/Select.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
   Button,
   Collection,
+  FieldError,
   Header,
   Key,
   Label,
@@ -14,6 +15,7 @@ import {
   SelectProps as ReactAriaSelectProps,
   SelectValue,
   Text,
+  ValidationResult,
 } from "react-aria-components";
 
 import "./Select.css";
@@ -50,6 +52,8 @@ export interface SelectProps<T extends object> extends ReactAriaSelectProps<T> {
   placeholder?: string;
   /** Defaults to `medium` */
   size?: "small" | "medium";
+  /* Used for data validation and error handling */
+  errorMessage?: string | ((validation: ValidationResult) => string);
 }
 
 function ChevronDown() {
@@ -93,6 +97,7 @@ export default function Select<T extends object>({
   label,
   placeholder,
   size = "medium",
+  errorMessage,
   ...props
 }: SelectProps<T>) {
   return (
@@ -125,6 +130,9 @@ export default function Select<T extends object>({
             />
             {isOpen ? <ChevronUp /> : <ChevronDown />}
           </Button>
+          <FieldError className="bcds-react-aria-Select--Error">
+            {errorMessage}
+          </FieldError>
           <Popover className="bcds-react-aria-Select--Popover" offset={4}>
             <ListBox
               className="bcds-react-aria-Select--ListBox"

--- a/packages/react-components/src/components/Select/Select.tsx
+++ b/packages/react-components/src/components/Select/Select.tsx
@@ -127,7 +127,6 @@ export default function Select<T extends object>({
               {label}
               {!isRequired && (
                 <>
-                  {" "}
                   <span className="optional">(optional)</span>
                 </>
               )}

--- a/packages/react-components/src/components/Select/Select.tsx
+++ b/packages/react-components/src/components/Select/Select.tsx
@@ -124,13 +124,7 @@ export default function Select<T extends object>({
         <>
           {label && (
             <Label className="bcds-react-aria-Select--Label">
-              {label}
-              {!isRequired && (
-                <>
-                  {" "}
-                  <span className="optional">(optional)</span>
-                </>
-              )}
+              {isRequired ? label : `${label} (optional)`}
             </Label>
           )}
           <Button

--- a/packages/react-components/src/components/Select/Select.tsx
+++ b/packages/react-components/src/components/Select/Select.tsx
@@ -127,6 +127,7 @@ export default function Select<T extends object>({
               {label}
               {!isRequired && (
                 <>
+                  {" "}
                   <span className="optional">(optional)</span>
                 </>
               )}

--- a/packages/react-components/src/stories/Select.stories.tsx
+++ b/packages/react-components/src/stories/Select.stories.tsx
@@ -11,9 +11,9 @@ const meta = {
       config: {
         // overrides automated accessibility testing for aria-hidden-focus to suppress a known false positive
         // see https://react-spectrum.adobe.com/react-aria/Select.html#false-positives for more information
-        rules: [{ id: 'aria-hidden-focus', enabled: false }],
-      }
-    }
+        rules: [{ id: "aria-hidden-focus", enabled: false }],
+      },
+    },
   },
   argTypes: {
     size: {
@@ -168,6 +168,7 @@ export const Invalid: Story = {
     ...SelectTemplate.args,
     label: "Invalid example",
     isInvalid: true,
+    errorMessage: "Error messages can be customised or passed programmatically",
   },
 };
 


### PR DESCRIPTION
This PR contains minor tweaks to the Select component, to address the issues documented in #388 (based on work done for #389):

- 1c0c452: shows a visible error icon to the Select `<Button>` element when the `isInvalid` prop is passed
- a56cd53: first pass at implementing validation and error handling using `FieldError` and `ValidationResult`. Creates an error message slot underneath the Select `<Button>`