### PR TITLE
Update button focus state to new design

### DIFF
--- a/packages/react-components/src/components/Button/Button.css
+++ b/packages/react-components/src/components/Button/Button.css
@@ -13,7 +13,9 @@
   cursor: not-allowed;
 }
 .bcds-react-aria-Button[data-focused] {
-  outline: 2px solid var(--surface-color-border-active);
+  outline: solid var(--layout-border-width-medium)
+    var(--surface-color-border-active);
+  outline-offset: var(--layout-margin-hair);
 }
 
 /* Icon button */


### PR DESCRIPTION
This PR changes the styling of the focus state for the button component, offsetting the outline on `[data-focused]` so that it's more visually prominent. 

New focus state is illustrated here:
![Screenshot 2024-06-20 at 15 02 09](https://github.com/bcgov/design-system/assets/135075821/3a0aa645-042b-49e0-9874-99a2d67ba764)
![Screenshot 2024-06-20 at 15 02 33](https://github.com/bcgov/design-system/assets/135075821/00e48471-1088-4837-9418-e9e166f92800)

