### PR TITLE
Update tag focus and select states to new design

### DIFF
--- a/packages/react-components/src/components/Tag/Tag.css
+++ b/packages/react-components/src/components/Tag/Tag.css
@@ -77,7 +77,7 @@
 /* Focused */
 .bcds-react-aria-Tag[data-focused] {
   outline: 2px solid var(--surface-color-border-active);
-  outline-offset: 0;
+  outline-offset: var(--layout-margin-hair);
 }
 
 /* Disabled */

--- a/packages/react-components/src/components/Tag/Tag.css
+++ b/packages/react-components/src/components/Tag/Tag.css
@@ -70,13 +70,16 @@
 
 /* Selected */
 .bcds-react-aria-Tag[data-selected] {
-  border: 2px solid var(--surface-color-border-active);
-  padding: 1px 7px;
+  border-radius: var(--layout-border-radius-small);
+  border: var(--layout-border-width-medium) solid
+    var(--surface-color-border-active);
+  padding: var(--layout-margin-hair) var(--layout-padding-small);
 }
 
 /* Focused */
 .bcds-react-aria-Tag[data-focused] {
-  outline: 2px solid var(--surface-color-border-active);
+  outline: var(--layout-border-width-medium) solid
+    var(--surface-color-border-active);
   outline-offset: var(--layout-margin-hair);
 }
 

--- a/packages/react-components/src/components/Tag/Tag.css
+++ b/packages/react-components/src/components/Tag/Tag.css
@@ -3,17 +3,14 @@
   cursor: pointer;
   border-radius: var(--layout-margin-hair);
   border: 1px solid;
-  box-sizing: content-box;
+  display: flex;
+  align-items: center;
+  gap: 8px;
   font: var(--typography-regular-label);
   padding: 2px 8px;
   width: fit-content;
 }
-.bcds-react-aria-Tag--contents {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-.bcds-react-aria-Tag--contents .react-aria-Button {
+.bcds-react-aria-Tag .react-aria-Button {
   background: none;
   border: none;
   color: var(--typography-color-primary);
@@ -29,9 +26,7 @@
   border-color: var(--theme-blue-90);
   color: var(--typography-color-primary-invert);
 }
-.bcds-react-aria-Tag.bc-blue
-  .bcds-react-aria-Tag--contents
-  > .react-aria-Button {
+.bcds-react-aria-Tag.bc-blue .react-aria-Button {
   color: var(--typography-color-primary-invert);
 }
 .bcds-react-aria-Tag.bc-gold {
@@ -47,7 +42,7 @@
   border-color: var(--theme-blue-90);
   color: var(--typography-color-primary-invert);
 }
-.bcds-react-aria-Tag.dark .bcds-react-aria-Tag--contents > .react-aria-Button {
+.bcds-react-aria-Tag.dark .react-aria-Button {
   color: var(--typography-color-primary-invert);
 }
 .bcds-react-aria-Tag.gray,
@@ -73,7 +68,6 @@
   border-radius: var(--layout-border-radius-small);
   border: var(--layout-border-width-medium) solid
     var(--surface-color-border-active);
-  padding: var(--layout-margin-hair) var(--layout-padding-small);
 }
 
 /* Focused */

--- a/packages/react-components/src/components/Tag/Tag.tsx
+++ b/packages/react-components/src/components/Tag/Tag.tsx
@@ -35,7 +35,7 @@ export default function Tag({ color = "blue", icon, id, textValue }: TagProps) {
       textValue={textValue}
     >
       {({ allowsRemoving, isDisabled }: TagRenderProps) => (
-        <div className="bcds-react-aria-Tag--contents">
+        <>
           {icon}
           {textValue}
           {!isDisabled && allowsRemoving && (
@@ -57,7 +57,7 @@ export default function Tag({ color = "blue", icon, id, textValue }: TagProps) {
               </svg>
             </ReactAriaButton>
           )}
-        </div>
+        </>
       )}
     </ReactAriaTag>
   );


### PR DESCRIPTION
This PR implements the new offset-ring focus state design on the tag component.

This change makes it easier to distinguish when a tag is in focus, selected or both:

<img width="680" alt="Screenshot 2024-06-25 at 13 55 35" src="https://github.com/bcgov/design-system/assets/135075821/eb80c658-d13c-4acc-a8a6-b0cbb42fc1b8">

[New design in Figma](https://www.figma.com/design/2OhHsH2ztSFUwDcVzxug7Z/BC-Design-System?node-id=3347-129&m=dev), for reference.