### PR TITLE
Storybook Nginx configuration for production deployment

### DIFF
--- a/packages/react-components/Dockerfile.storybook
+++ b/packages/react-components/Dockerfile.storybook
@@ -3,7 +3,7 @@
 # -----------
 # Build stage
 # -----------
-FROM node:lts-alpine as build-stage
+FROM node:lts-alpine AS build-stage
 ARG GITHUB_SHA
 ENV GITHUB_SHA=$GITHUB_SHA
 
@@ -30,7 +30,7 @@ RUN STORYBOOK_GITHUB_SHA=$GITHUB_SHA npm run storybook-build
 # -----------
 # Serve stage
 # -----------
-FROM nginxinc/nginx-unprivileged:alpine as serve-stage
+FROM nginxinc/nginx-unprivileged:alpine AS serve-stage
 
 # Copy nginx configuration
 COPY ./nginx.storybook.conf /etc/nginx/nginx.conf

--- a/packages/react-components/Dockerfile.vite
+++ b/packages/react-components/Dockerfile.vite
@@ -3,7 +3,7 @@
 # -----------
 # Build stage
 # -----------
-FROM node:lts-alpine as build-stage
+FROM node:lts-alpine AS build-stage
 
 # Copy package.json and package-lock.json
 WORKDIR /app
@@ -28,7 +28,7 @@ RUN npm run vite-build
 # -----------
 # Serve stage
 # -----------
-FROM nginxinc/nginx-unprivileged:alpine as serve-stage
+FROM nginxinc/nginx-unprivileged:alpine AS serve-stage
 
 # Copy nginx configuration
 COPY ./nginx.vite.conf /etc/nginx/nginx.conf

--- a/packages/react-components/nginx.storybook.conf
+++ b/packages/react-components/nginx.storybook.conf
@@ -26,9 +26,24 @@ http {
     error_log  /tmp/error.log;
     access_log /tmp/access.log;
 
-    location / {
-      root /usr/share/nginx/html;
-      try_files $uri /index.html;
+    # Redirect requests for root to gov.bc.ca B.C. Design System landing page
+    # Perma-link: https://www2.gov.bc.ca/gov/content?id=67906B3698E44F4592AD4C6DC375B8F1
+    location = / {
+      return 301 https://gov.bc.ca/designsystem;
     }
+
+    # Requests within /react-components/ path get served the Storybook app
+    location /react-components/ {
+      alias /usr/share/nginx/html/;
+      try_files $uri $uri/ /index.html;
+    }
+
+    # Redirect /react-components to /react-components/
+    location = /react-components {
+      return 301 /react-components/;
+    }
+
+    # Redirect 404 errors to the Design System landing page
+    error_page 404 =301 https://gov.bc.ca/designsystem;
   }
 }


### PR DESCRIPTION
This updates the React component library's Storybook app Nginx configuration to handle routing according to these rules:

- Requests to `/` will be redirected to the [B.C. Design System landing page on gov.bc.ca](https://gov.bc.ca/designsystem)
  - Ex: A GET request to `https://<design-system-subdomain>.gov.bc.ca` will go to BCDS page
- Requests to any valid address starting with `/react-components/` will get served the Storybook app, which handles its own routing client-side after the first page load
  - Ex: A GET request to `https://<design-system-subdomain>.gov.bc.ca/react-components/` will go to Storybook
  - Ex: `https://<design-system-subdomain>.gov.bc.ca/react-components/?path=/docs/components-button-button--docs` goes to Storybook's Button documentation page
- Requests to `/react-components` will be redirected to `/react-components/` (trailing slash)
- Requests that would result in 404 errors are redirected to the BCDS page

Keeping this Nginx configuration where it is makes sense for now, but it might need a re-think if we start serving multiple apps from one subdomain at different paths. In that case, it might make more sense to move the Nginx configuration to somewhere else in this repo, outside of `packages/react-components`.