### PR TITLE
React components v0.0.8

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.0.8
+
+### Changed
+
+- Updated Button component focus state.
+- Updated Tag component focus and select states.
+- Fixed Select component long option text overflow bug.
+
+### Added
+
+- Added TextField component.
+
 ## 0.0.7
 
 ### Changed

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgov/design-system-react-components",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@bcgov/design-tokens": "3.0.0",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "module",
   "scripts": {
     "rollup": "rm -rf dist && rollup -c --bundleConfigAsCjs",


### PR DESCRIPTION
This PR moves the React components library to v0.0.8. This is currently published on the `next` tag on npm as [v0.0.8-rc1](https://www.npmjs.com/package/@bcgov/design-system-react-components/v/0.0.8-rc1).

This version includes the TextField component and focus style updates to the Button, Select, and Tag components.

Once this is merged, I will publish v0.0.8 to npm on the default `latest` tag.