### PR TITLE
Text Field - remove unnecessary padding rule from label

### DIFF
--- a/packages/react-components/src/components/TextField/TextField.css
+++ b/packages/react-components/src/components/TextField/TextField.css
@@ -11,7 +11,6 @@
 .bcds-react-aria-TextField--Label {
   font: var(--typography-regular-small-body);
   color: var(--typography-color-primary);
-  padding: var(--layout-margin-hair) 0px;
 }
 
 .bcds-react-aria-TextField--Label .required {


### PR DESCRIPTION
Does what it says on the tin — nixes 2px worth of unnecessary padding from the label above a text field.