### PR TITLE
Select - visible label when required rather than optional

### DIFF
--- a/packages/react-components/src/components/Select/Select.tsx
+++ b/packages/react-components/src/components/Select/Select.tsx
@@ -124,7 +124,7 @@ export default function Select<T extends object>({
         <>
           {label && (
             <Label className="bcds-react-aria-Select--Label">
-              {isRequired ? label : `${label} (optional)`}
+              {isRequired ? `${label} (required)` : label}
             </Label>
           )}
           <Button

--- a/packages/react-components/src/stories/Select.mdx
+++ b/packages/react-components/src/stories/Select.mdx
@@ -71,7 +71,7 @@ Choose from medium (default) and small select sizes:
 
 ### Required
 
-By default, select fields are not required, and "(optional)" appears in the label. Use `isRequired` to mark the select field as required:
+By default, select fields are not required. Use `isRequired` to mark the field as required, and display a "(required)" label:
 
 <Canvas of={SelectStories.Required} />
 


### PR DESCRIPTION
This change changes how the `isRequired` prop is handled, to align with behaviour of TextField and TextArea. The goal is internal consistency and strict compliance with [WCAG SC 3.3.2](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html).

With this change, when `isRequired` is true, a secondary "(required)" label is rendered. When `isRequired` is false, only the primary label is displayed.

Old behaviour:
<img width="299" alt="Screenshot 2024-07-23 at 10 25 47" src="https://github.com/user-attachments/assets/1c453bba-13cc-44c4-a23c-59ee05883a7a">

New behaviour:
<img width="405" alt="Screenshot 2024-07-23 at 10 25 26" src="https://github.com/user-attachments/assets/b981ee03-808f-493f-b70a-ca7eb0e2abae">