### PR TITLE
Update label spacing on various components

### DIFF
--- a/packages/react-components/src/components/Select/Select.css
+++ b/packages/react-components/src/components/Select/Select.css
@@ -1,7 +1,6 @@
 .bcds-react-aria-Select {
   display: flex;
   flex-direction: column;
-  gap: var(--layout-margin-small);
   align-items: flex-start;
   /* Hacks for `stretch`: https://caniuse.com/mdn-css_properties_max-width_stretch */
   max-width: -moz-available;
@@ -12,6 +11,7 @@
 .bcds-react-aria-Select--Label {
   color: var(--typography-color-secondary);
   font: var(--typography-regular-small-body);
+  padding: var(--layout-padding-xsmall) var(--layout-padding-none);
 }
 .bcds-react-aria-Select[data-disabled] > .bcds-react-aria-Select--Label {
   color: var(--typography-color-disabled);

--- a/packages/react-components/src/components/TagGroup/TagGroup.css
+++ b/packages/react-components/src/components/TagGroup/TagGroup.css
@@ -7,7 +7,7 @@
 .bcds-react-aria-TagGroup--Text-description,
 .bcds-react-aria-TagGroup--Text-error {
   display: block;
-  margin: var(--layout-margin-small) var(--layout-margin-none);
+  padding: var(--layout-padding-xsmall) var(--layout-padding-none);
 }
 
 .bcds-react-aria-TagGroup--Text-error {

--- a/packages/react-components/src/components/TextArea/TextArea.css
+++ b/packages/react-components/src/components/TextArea/TextArea.css
@@ -14,11 +14,6 @@
   padding: var(--layout-padding-xsmall) var(--layout-padding-none);
 }
 
-.bcds-react-aria-TextArea--Label > .required {
-  color: var(--typography-color-secondary);
-  padding: var(--layout-padding-none) var(--layout-padding-xsmall);
-}
-
 /* Styles for the description and character count slot below the input field */
 .bcds-react-aria-TextArea--Description {
   display: grid;

--- a/packages/react-components/src/components/TextArea/TextArea.css
+++ b/packages/react-components/src/components/TextArea/TextArea.css
@@ -11,6 +11,7 @@
 .bcds-react-aria-TextArea--Label {
   font: var(--typography-regular-small-body);
   color: var(--typography-color-primary);
+  padding: var(--layout-padding-xsmall) var(--layout-padding-none);
 }
 
 .bcds-react-aria-TextArea--Label > .required {
@@ -22,6 +23,7 @@
 .bcds-react-aria-TextArea--Description {
   display: grid;
   gap: var(--layout-margin-medium);
+  padding: var(--layout-padding-xsmall) var(--layout-padding-none);
   font: var(--typography-regular-small-body);
   color: var(--typography-color-secondary);
 }
@@ -51,7 +53,6 @@
     var(--surface-color-border-default);
   border-radius: var(--layout-border-radius-medium);
   padding: var(--layout-padding-small) 12px;
-  margin: var(--layout-margin-small) var(--layout-margin-none);
 }
 
 /* Text input field */

--- a/packages/react-components/src/components/TextArea/TextArea.tsx
+++ b/packages/react-components/src/components/TextArea/TextArea.tsx
@@ -44,8 +44,7 @@ export default function TextArea({
         <>
           {label && (
             <Label className="bcds-react-aria-TextArea--Label">
-              {label}
-              {isRequired && <span className="required">(required)</span>}
+              {isRequired ? `${label} (required)` : label}
             </Label>
           )}
           <div className="bcds-react-aria-TextArea--Container">

--- a/packages/react-components/src/components/TextField/TextField.css
+++ b/packages/react-components/src/components/TextField/TextField.css
@@ -14,11 +14,6 @@
   padding: var(--layout-padding-xsmall) var(--layout-padding-none);
 }
 
-.bcds-react-aria-TextField--Label .required {
-  color: var(--typography-color-secondary);
-  padding: var(--layout-padding-none) var(--layout-padding-xsmall);
-}
-
 /* Styles for the text description below the input field */
 .bcds-react-aria-TextField--Description {
   font: var(--typography-regular-small-body);

--- a/packages/react-components/src/components/TextField/TextField.css
+++ b/packages/react-components/src/components/TextField/TextField.css
@@ -14,6 +14,11 @@
   padding: var(--layout-padding-xsmall) var(--layout-padding-none);
 }
 
+.bcds-react-aria-TextField--Label .required {
+  color: var(--typography-color-secondary);
+  padding: var(--layout-padding-none) var(--layout-padding-xsmall);
+}
+
 /* Styles for the text description below the input field */
 .bcds-react-aria-TextField--Description {
   font: var(--typography-regular-small-body);

--- a/packages/react-components/src/components/TextField/TextField.css
+++ b/packages/react-components/src/components/TextField/TextField.css
@@ -11,6 +11,7 @@
 .bcds-react-aria-TextField--Label {
   font: var(--typography-regular-small-body);
   color: var(--typography-color-primary);
+  padding: var(--layout-padding-xsmall) var(--layout-padding-none);
 }
 
 .bcds-react-aria-TextField--Label .required {
@@ -22,6 +23,7 @@
 .bcds-react-aria-TextField--Description {
   font: var(--typography-regular-small-body);
   color: var(--typography-color-secondary);
+  padding: var(--layout-padding-xsmall) var(--layout-padding-none);
 }
 
 /* Styles for the input field container */
@@ -36,7 +38,6 @@
   border: var(--layout-border-width-small) solid
     var(--surface-color-border-default);
   border-radius: var(--layout-border-radius-medium);
-  margin: var(--layout-margin-small) var(--layout-margin-none);
   padding: var(--layout-padding-small) 12px;
 }
 

--- a/packages/react-components/src/components/TextField/TextField.tsx
+++ b/packages/react-components/src/components/TextField/TextField.tsx
@@ -58,7 +58,12 @@ export default function TextField({
         <>
           {label && (
             <Label className="bcds-react-aria-TextField--Label">
-              {isRequired ? `${label} (required)` : label}
+              {label}
+              {isRequired && (
+                <span className="bcds-react-aria-TextField--Label required">
+                  (required)
+                </span>
+              )}
             </Label>
           )}
           <div

--- a/packages/react-components/src/components/TextField/TextField.tsx
+++ b/packages/react-components/src/components/TextField/TextField.tsx
@@ -58,12 +58,7 @@ export default function TextField({
         <>
           {label && (
             <Label className="bcds-react-aria-TextField--Label">
-              {label}
-              {isRequired && (
-                <span className="bcds-react-aria-TextField--Label required">
-                  (required)
-                </span>
-              )}
+              {isRequired ? `${label} (required)` : label}
             </Label>
           )}
           <div


### PR DESCRIPTION
This change does two things, across all of our input components:

**Make spacing between label and component consistent**

- 26253991038f5704e202715f98bed42ae4f172e6: Select
- 42905cbaccc2bcebcd7dadb748bd10a4938d7b79: TagGroup
- fbe64cfede29802e5a29adc67fc1218b0c9ecf03: TextField
- 70093fc9b7ed70af0ef44285e458c074bc3d338d: TextArea

**Clean up and simplify styling of (required) label**
- ff872859fc1bce46353dafcedd0bf8b088729cb6: TextArea
- 2e600fc560d251f8b62ea7c9a9322fac53b26e8a: TextField