### PR TITLE
React components library v0.0.10

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.0.10
+
+### Changed
+
+- Select, TextArea, and TextField components use "(required)" in label when `isRequired` prop is true, rather than "(optional)" when false.
+- Select, TagGroup, TextArea, and TextField components have text slot spacing adjusted for consistency between components.
+
+### Added
+
+- Added Form utility component.
+
 ## 0.0.9
 
 ### Changed

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -72,6 +72,7 @@ export default function App() {
 | ----------------------- | ---------------------------------------------------------- |
 | Button                  | https://react-spectrum.adobe.com/react-aria/Button.html    |
 | Footer                  | N/A                                                        |
+| Form                    | https://react-spectrum.adobe.com/react-aria/Form.html      |
 | Header                  | N/A                                                        |
 | Select                  | https://react-spectrum.adobe.com/react-aria/Select.html    |
 | TagGroup, TagList, Tag  | https://react-spectrum.adobe.com/react-aria/TagGroup.html  |

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgov/design-system-react-components",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@bcgov/design-tokens": "3.0.0",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "scripts": {
     "rollup": "rm -rf dist && rollup -c --bundleConfigAsCjs",


### PR DESCRIPTION
This PR moves the React components library to v0.0.10. This code is currently published on npm as `@bcgov/design-system-react-components` on the `next` tag at v0.0.10-rc3.

- Changelog updated to reflect Form component addition #409, and `isRequired` label and text slot spacing #416.
- Readme updated to add Form component link.

Once this is merged, I will publish v0.0.10 on the `latest` tag.