### PR TITLE
Add publish_react_component_library.yaml GitHub Actions workflow file

### DIFF
--- a/.github/workflows/publish_react_component_library.yaml
+++ b/.github/workflows/publish_react_component_library.yaml
@@ -1,0 +1,67 @@
+name: Publish @bcgov/design-system-react-components to npm @next
+
+on:
+  pull_request:
+    paths:
+      - packages/react-components/**
+    branches: [main]
+    types: [closed]
+
+jobs:
+  publish-react-component-library:
+    name: Public @bcgov/design-system-react-components
+    # Only run on merge, not close without merge
+    if: github.event.pull_request.merged == true
+    # Only run in bcgov/design-system repo, not forks
+    if: github.repository == 'bcgov/design-system'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Read .nvmrc
+      run: echo "GITHUB_NVMRC_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV
+      working-directory: ./packages/react-components
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ env.GITHUB_NVMRC_VERSION }}
+
+    - name: Install dependencies
+      run: npm install
+      working-directory: ./packages/react-components
+
+    - name: Install jq
+      run: sudo apt-get install -y jq
+
+    # Use `jq` to change the package.json version to look like:
+    #
+    #   <version in package.json>-pr<PR # that caused the workflow run>
+    #
+    # So package.json version v1.2.3 with a run caused by merging PR #456 to
+    # `main` causes the version of the package on npm to look like:
+    #
+    #   1.2.3-pr456
+    #
+    # This is to ensure that it's easy to map an npm version to a particular PR.
+    #
+    - name: Update version in package.json
+      run: |
+        PR_NUMBER=${{ github.event.pull_request.number }}
+        CURRENT_VERSION=$(jq -r '.version' package.json)
+        NEW_VERSION="${CURRENT_VERSION}-pr${PR_NUMBER}"
+        jq --arg new_version "$NEW_VERSION" '.version = $new_version' package.json > tmp.json && mv tmp.json package.json
+      shell: bash
+      working-directory: ./packages/react-components
+
+    - name: Build with Rollup script
+      run: npm run rollup
+      working-directory: ./packages/react-components
+
+    - name: Publish to npm
+      run: npm publish --tag next
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      working-directory: ./packages/react-components


### PR DESCRIPTION
This PR adds a GitHub Actions workflow file that is designed to publish a new version of `@bcgov/design-system-react-components` on npm using the `next` tag and with a version that looks like:

```
<current version from package.json>-pr<number of the pull request that triggered the action>
```

So package.json version v1.2.3 with a build caused by PR # 456 would result in an npm version of `1.2.3-pr456` on the `next` tag (not the default `latest` tag that gives the canonical latest version of the package when a user installs with `npm install`).

The intent is that we are able to publish and test new versions of the library quickly with less manual action needed.

I have a secret `NPM_TOKEN` already added to this repo that this workflow will use. I'm not 100% sure how this will work with npm's MFA requirement that I bump up against every time I manually publish a new version, so we will have to test this if it gets merged.