### PR TITLE
Update actions/checkout version in React components publish workflow

### DIFF
--- a/.github/workflows/publish_react_component_library.yaml
+++ b/.github/workflows/publish_react_component_library.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish-react-component-library:
-    name: Public @bcgov/design-system-react-components
+    name: Publish @bcgov/design-system-react-components@next
     # Only run on merge, not close without merge AND
     # only run in bcgov/design-system repo, not forks.
     if: ${{ github.event.pull_request.merged == true && github.repository == 'bcgov/design-system' }}
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Read .nvmrc
         run: echo "GITHUB_NVMRC_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -165,4 +165,8 @@ Copy the Changelog notes for the new version and link to the npm page for the ne
 
 ### GitHub Actions
 
-GitHub Actions to build, test, and publish new versions (on the `next` tag on npm) of the library are located in `/.github/workflows` in the project root.
+GitHub Actions are located in `/.github/workflows` in the project root. Actions are included to:
+
+- Build the Storybook and Vite applications on merge to `main`
+- Test (Jest and Playwright) on pull request
+- Publish new versions of the library on npm (`next` tag) on merge to `main`


### PR DESCRIPTION
With the publish workflow now working (see [this workflow run](https://github.com/bcgov/design-system/actions/runs/10085566433) and [this resulting npm package version](https://www.npmjs.com/package/@bcgov/design-system-react-components/v/0.1.0-pr427)), this PR cleans up the workflow file by moving `actions/checkout` to the latest version and by cleaning up the new README content to generate another run of the workflow.