### PR TITLE
TagGroup - add warning icon to error message

### DIFF
--- a/packages/react-components/src/components/TagGroup/TagGroup.css
+++ b/packages/react-components/src/components/TagGroup/TagGroup.css
@@ -11,5 +11,13 @@
 }
 
 .bcds-react-aria-TagGroup--Text-error {
+  display: flex;
   color: var(--typography-color-danger);
+}
+
+.bcds-react-aria-TagGroup--Text-error > svg {
+  padding-right: var(--layout-padding-xsmall);
+  color: var(--icons-color-danger);
+  width: var(--icons-size-medium);
+  height: var(--icons-size-medium);
 }

--- a/packages/react-components/src/components/TagGroup/TagGroup.css
+++ b/packages/react-components/src/components/TagGroup/TagGroup.css
@@ -18,6 +18,6 @@
 .bcds-react-aria-TagGroup--Text-error > svg {
   padding-right: var(--layout-padding-xsmall);
   color: var(--icons-color-danger);
-  width: var(--icons-size-medium);
+  min-width: var(--icons-size-medium);
   height: var(--icons-size-medium);
 }

--- a/packages/react-components/src/components/TagGroup/TagGroup.tsx
+++ b/packages/react-components/src/components/TagGroup/TagGroup.tsx
@@ -6,6 +6,7 @@ import {
 } from "react-aria-components";
 
 import "./TagGroup.css";
+import SvgExclamationIcon from "../SvgExclamationIcon";
 
 export interface TagGroupProps extends ReactAriaTagGroupProps {
   /**
@@ -48,6 +49,7 @@ export default function TagGroup({
           slot="errorMessage"
           className="bcds-react-aria-TagGroup--Text-error"
         >
+          <SvgExclamationIcon />
           {errorMessage}
         </Text>
       )}


### PR DESCRIPTION
This change adds a visible warning icon alongside the `errorMessage` displayed when TagGroup is in an invalid state. This mirrors behaviour from the TextArea component, and is intended to improve conformance with [WCAG SC 1.4.1](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html)

Before:
<img width="311" alt="Screenshot 2024-07-25 at 09 08 59" src="https://github.com/user-attachments/assets/7d508634-56fe-4af3-926d-562857af2839">

After:
<img width="301" alt="Screenshot 2024-07-25 at 09 08 49" src="https://github.com/user-attachments/assets/327febec-8838-466c-b001-c2ae632a1bfd">