### PR TITLE
Select - expose description field

### DIFF
--- a/packages/react-components/src/components/Select/Select.css
+++ b/packages/react-components/src/components/Select/Select.css
@@ -17,6 +17,13 @@
   color: var(--typography-color-disabled);
 }
 
+/* Rext description below select input */
+.bcds-react-aria-Select--Description {
+  font: var(--typography-regular-small-body);
+  color: var(--typography-color-secondary);
+  padding: var(--layout-padding-xsmall) var(--layout-padding-none);
+}
+
 /* Error message */
 .bcds-react-aria-Select--Error {
   font: var(--typography-regular-small-body);

--- a/packages/react-components/src/components/Select/Select.tsx
+++ b/packages/react-components/src/components/Select/Select.tsx
@@ -52,7 +52,9 @@ export interface SelectProps<T extends object> extends ReactAriaSelectProps<T> {
   placeholder?: string;
   /** Defaults to `medium` */
   size?: "small" | "medium";
-  /* Used for data validation and error handling */
+  /** Description or helper text that renders below the select input */
+  description?: string;
+  /** Used for data validation and error handling */
   errorMessage?: string | ((validation: ValidationResult) => string);
 }
 
@@ -113,6 +115,7 @@ export default function Select<T extends object>({
   items,
   sections,
   label,
+  description,
   placeholder,
   size = "medium",
   errorMessage,
@@ -143,6 +146,14 @@ export default function Select<T extends object>({
             {isInvalid && iconError}
             {isOpen ? <ChevronUp /> : <ChevronDown />}
           </Button>
+          {description && (
+            <Text
+              slot="description"
+              className={`bcds-react-aria-Select--Description`}
+            >
+              {description}
+            </Text>
+          )}
           <FieldError className="bcds-react-aria-Select--Error">
             {errorMessage}
           </FieldError>

--- a/packages/react-components/src/stories/Select.stories.tsx
+++ b/packages/react-components/src/stories/Select.stories.tsx
@@ -35,6 +35,10 @@ const meta = {
       description:
         "Text label that appears inside the select input before an option has been selected",
     },
+    errorMessage: {
+      control: { type: "text" },
+      description: "Text displayed when the input is invalid",
+    },
   },
 } satisfies Meta<typeof Select>;
 

--- a/packages/react-components/src/stories/Select.stories.tsx
+++ b/packages/react-components/src/stories/Select.stories.tsx
@@ -25,6 +25,11 @@ const meta = {
       control: { type: "text" },
       description: "Text label that appears above the select button",
     },
+    description: {
+      control: { type: "text" },
+      description:
+        "Additional description or helper text below the select button",
+    },
     placeholder: {
       control: { type: "text" },
       description:
@@ -55,6 +60,7 @@ export const SelectTemplate: Story = {
   args: {
     label: "Label",
     size: "medium",
+    description: "Optional description or helper text",
     isRequired: false,
     isDisabled: false,
     isInvalid: false,


### PR DESCRIPTION
This PR adds an optional description/helper text field to the Select component, rendering below the selector input. The styling and behaviour of this description field follows the pattern of our other input components:

![Screenshot 2024-07-25 at 10 36 33](https://github.com/user-attachments/assets/30d04356-2c0b-490c-a478-ca31d324a3ef)

@Philip-Cheung as with #429, if you're happy with this let's also add this to the Figma component in our next release, please!