### PR TITLE
React components library v0.1.1

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.1
+
+### Changed
+
+- Use `react-aria-components` v1.3.1.
+
 # 0.1.0
 
 This is a milestone release that contains the following components:

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgov/design-system-react-components",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@bcgov/design-tokens": "3.0.0",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "rollup": "rm -rf dist && rollup -c --bundleConfigAsCjs",


### PR DESCRIPTION
This PR moves `@bcgov/design-system-react-components` to v0.1.1. This code is published on the `next` tag on npm now as [v0.1.1-rc1](https://www.npmjs.com/package/@bcgov/design-system-react-components/v/0.1.1-rc1).

The only change in this release is bumping `react-aria-components` from v1.2.1 to v1.3.1 (#432). See [React Spectrum July 22, 2024 release notes](https://react-spectrum.adobe.com/releases/2024-07-22.html) for details on newly available functionality.

Once this is merged, I will publish `@bcgov/design-system-react-components` at v0.1.1 on the `latest` tag on npm.