### PR TITLE
Add ButtonGroup component and refactor Inline Alert

### DIFF
--- a/packages/react-components/src/App.tsx
+++ b/packages/react-components/src/App.tsx
@@ -8,6 +8,7 @@ import { Button, Footer, FooterLinks, Header } from "@/components";
 import useWindowDimensions from "@/hooks/useWindowDimensions";
 import {
   ButtonPage,
+  ButtonGroupPage,
   InlineAlertPage,
   SelectPage,
   TagGroupPage,
@@ -148,6 +149,7 @@ function App() {
       <main>
         <h1>Components</h1>
         <ButtonPage />
+        <ButtonGroupPage />
         <SwitchPage />
         <InlineAlertPage />
         <SelectPage />

--- a/packages/react-components/src/components/ButtonGroup/ButtonGroup.css
+++ b/packages/react-components/src/components/ButtonGroup/ButtonGroup.css
@@ -16,6 +16,10 @@
   justify-content: flex-start;
 }
 
+.bcds-ButtonGroup.center {
+  justify-content: center;
+}
+
 .bcds-ButtonGroup.end {
   justify-content: flex-end;
 }

--- a/packages/react-components/src/components/ButtonGroup/ButtonGroup.css
+++ b/packages/react-components/src/components/ButtonGroup/ButtonGroup.css
@@ -1,6 +1,7 @@
 .bcds-ButtonGroup {
   display: flex;
   gap: var(--layout-margin-small);
+  flex-grow: 1;
 }
 
 .bcds-ButtonGroup.horizontal {
@@ -9,4 +10,12 @@
 
 .bcds-ButtonGroup.vertical {
   flex-direction: column;
+}
+
+.bcds-ButtonGroup.start {
+  align-items: flex-start;
+}
+
+.bcds-ButtonGroup.end {
+  align-items: flex-end;
 }

--- a/packages/react-components/src/components/ButtonGroup/ButtonGroup.css
+++ b/packages/react-components/src/components/ButtonGroup/ButtonGroup.css
@@ -1,2 +1,12 @@
 .bcds-ButtonGroup {
+  display: flex;
+  gap: var(--layout-margin-small);
+}
+
+.bcds-ButtonGroup.horizontal {
+  flex-direction: row;
+}
+
+.bcds-ButtonGroup.vertical {
+  flex-direction: column;
 }

--- a/packages/react-components/src/components/ButtonGroup/ButtonGroup.css
+++ b/packages/react-components/src/components/ButtonGroup/ButtonGroup.css
@@ -13,9 +13,9 @@
 }
 
 .bcds-ButtonGroup.start {
-  align-items: flex-start;
+  justify-content: flex-start;
 }
 
 .bcds-ButtonGroup.end {
-  align-items: flex-end;
+  justify-content: flex-end;
 }

--- a/packages/react-components/src/components/ButtonGroup/ButtonGroup.css
+++ b/packages/react-components/src/components/ButtonGroup/ButtonGroup.css
@@ -1,0 +1,2 @@
+.bcds-ButtonGroup {
+}

--- a/packages/react-components/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react-components/src/components/ButtonGroup/ButtonGroup.tsx
@@ -6,12 +6,13 @@ export interface ButtonGroupProps extends React.PropsWithChildren {
   /* Sets alignment of button group */
   alignment?: "start" | "center" | "end";
   /* Semantic label for button group */
-  "aria-label"?: string | undefined;
+  ariaLabel?: string | undefined;
 }
 
 export default function ButtonGroup({
   orientation = "horizontal",
   alignment = "start",
+  ariaLabel,
   children,
   ...props
 }: ButtonGroupProps) {
@@ -19,6 +20,7 @@ export default function ButtonGroup({
     <div
       className={`bcds-ButtonGroup ${orientation} ${alignment}`}
       role="group"
+      aria-label={ariaLabel}
       {...props}
     >
       {children}

--- a/packages/react-components/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react-components/src/components/ButtonGroup/ButtonGroup.tsx
@@ -3,17 +3,24 @@ import "./ButtonGroup.css";
 export interface ButtonGroupProps extends React.PropsWithChildren {
   /* Sets layout of button group */
   orientation?: "horizontal" | "vertical";
+  /* Sets alignment of button group */
+  alignment?: "start" | "end";
   /* Semantic label for button group */
   "aria-label"?: string | undefined;
 }
 
 export default function ButtonGroup({
   orientation,
+  alignment,
   children,
   ...props
 }: ButtonGroupProps) {
   return (
-    <div className={`bcds-ButtonGroup ${orientation}`} role="group" {...props}>
+    <div
+      className={`bcds-ButtonGroup ${orientation} ${alignment}`}
+      role="group"
+      {...props}
+    >
       {children}
     </div>
   );

--- a/packages/react-components/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react-components/src/components/ButtonGroup/ButtonGroup.tsx
@@ -4,7 +4,7 @@ export interface ButtonGroupProps extends React.PropsWithChildren {
   /* Sets layout of button group */
   orientation?: "horizontal" | "vertical";
   /* Sets alignment of button group */
-  alignment?: "start" | "end";
+  alignment?: "start" | "center" | "end";
   /* Semantic label for button group */
   "aria-label"?: string | undefined;
 }

--- a/packages/react-components/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react-components/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,0 +1,13 @@
+import "./ButtonGroup.css";
+
+export interface ButtonGroupProps extends React.PropsWithChildren {
+  orientation?: "horizontal" | "vertical";
+}
+
+export default function ButtonGroup({ children, ...props }: ButtonGroupProps) {
+  return (
+    <div className="bcds-ButtonGroup" {...props}>
+      {children}
+    </div>
+  );
+}

--- a/packages/react-components/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react-components/src/components/ButtonGroup/ButtonGroup.tsx
@@ -1,12 +1,19 @@
 import "./ButtonGroup.css";
 
 export interface ButtonGroupProps extends React.PropsWithChildren {
+  /* Sets layout of button group */
   orientation?: "horizontal" | "vertical";
+  /* Semantic label for button group */
+  "aria-label"?: string | undefined;
 }
 
-export default function ButtonGroup({ children, ...props }: ButtonGroupProps) {
+export default function ButtonGroup({
+  orientation,
+  children,
+  ...props
+}: ButtonGroupProps) {
   return (
-    <div className="bcds-ButtonGroup" {...props}>
+    <div className={`bcds-ButtonGroup ${orientation}`} role="group" {...props}>
       {children}
     </div>
   );

--- a/packages/react-components/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react-components/src/components/ButtonGroup/ButtonGroup.tsx
@@ -10,8 +10,8 @@ export interface ButtonGroupProps extends React.PropsWithChildren {
 }
 
 export default function ButtonGroup({
-  orientation,
-  alignment,
+  orientation = "horizontal",
+  alignment = "start",
   children,
   ...props
 }: ButtonGroupProps) {

--- a/packages/react-components/src/components/ButtonGroup/index.ts
+++ b/packages/react-components/src/components/ButtonGroup/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./ButtonGroup";
+export type { ButtonGroupProps } from "./ButtonGroup";

--- a/packages/react-components/src/components/InlineAlert/InlineAlert.css
+++ b/packages/react-components/src/components/InlineAlert/InlineAlert.css
@@ -94,3 +94,8 @@
 .bcds-Inline-Alert.danger > .bcds-Inline-Alert--icon {
   color: var(--icons-color-danger);
 }
+
+/* Button group */
+.bcds-Inline-Alert--container > .bcds-ButtonGroup {
+  padding-top: var(--layout-padding-small);
+}

--- a/packages/react-components/src/components/InlineAlert/InlineAlert.tsx
+++ b/packages/react-components/src/components/InlineAlert/InlineAlert.tsx
@@ -64,7 +64,7 @@ export default function InlineAlert({
       <div
         className="bcds-Inline-Alert--container"
         role={role}
-        aria-labelledby="alert-title" // this doesn't work
+        aria-labelledby={"alert-title"}
       >
         {children ? (
           children

--- a/packages/react-components/src/components/InlineAlert/InlineAlert.tsx
+++ b/packages/react-components/src/components/InlineAlert/InlineAlert.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import "./InlineAlert.css";
 import {
   Button,
+  ButtonGroup,
   SvgInfoIcon,
   SvgCheckCircleIcon,
   SvgExclamationIcon,
@@ -16,6 +17,8 @@ export interface InlineAlertProps extends React.PropsWithChildren {
   title?: string;
   /* Alert description */
   description?: string;
+  /* Button group */
+  buttons?: React.ReactNode;
   /* Alert closeable state */
   isCloseable?: boolean;
   /* Show or hide left icon */
@@ -48,6 +51,7 @@ export default function InlineAlert({
   isIconHidden = false,
   isCloseable = false,
   role = "note",
+  buttons,
   children,
   onClose,
   ...props
@@ -60,7 +64,7 @@ export default function InlineAlert({
       <div
         className="bcds-Inline-Alert--container"
         role={role}
-        aria-labelledby="alert-title"
+        aria-labelledby="alert-title" // this doesn't work
       >
         {children ? (
           children
@@ -72,6 +76,11 @@ export default function InlineAlert({
               </span>
             )}
             {description && <span className="description">{description}</span>}
+            {buttons && (
+              <ButtonGroup alignment="end" orientation="horizontal">
+                {buttons}
+              </ButtonGroup>
+            )}
           </>
         )}
       </div>

--- a/packages/react-components/src/components/index.ts
+++ b/packages/react-components/src/components/index.ts
@@ -2,6 +2,7 @@ import "@bcgov/design-tokens/css/variables.css";
 
 export { default as InlineAlert } from "./InlineAlert";
 export { default as Button } from "./Button";
+export { default as ButtonGroup } from "./ButtonGroup";
 export { default as Header } from "./Header";
 export { default as Footer, FooterLinks } from "./Footer";
 export { default as Form } from "./Form";

--- a/packages/react-components/src/pages/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react-components/src/pages/ButtonGroup/ButtonGroup.tsx
@@ -1,0 +1,15 @@
+import { Button, ButtonGroup } from "@/components";
+
+export default function ButtonGroupPage() {
+  return (
+    <>
+      <h2>ButtonGroup</h2>
+      <ButtonGroup>
+        <Button variant="primary">Button 1</Button>
+        <Button variant="secondary">Button 2</Button>
+        <Button variant="tertiary">Button 3</Button>
+        <Button variant="link">Button 4</Button>
+      </ButtonGroup>
+    </>
+  );
+}

--- a/packages/react-components/src/pages/ButtonGroup/index.ts
+++ b/packages/react-components/src/pages/ButtonGroup/index.ts
@@ -1,0 +1,3 @@
+import ButtonGroupPage from "./ButtonGroup";
+
+export default ButtonGroupPage;

--- a/packages/react-components/src/pages/InlineAlert/InlineAlert.tsx
+++ b/packages/react-components/src/pages/InlineAlert/InlineAlert.tsx
@@ -34,16 +34,14 @@ export default function InlineAlertPage() {
         <InlineAlert
           variant="info"
           title="This is an alert that also has additional actions"
-          description="It uses button components in the children slot to display additional important actions that the user can take."
-          children={[
-            <>
-              <Button variant="secondary" size="small">
-                This is a secondary button
-              </Button>
-              <Button variant="primary" size="small">
-                This is a primary button
-              </Button>
-            </>,
+          description="It uses button components to display additional important actions that the user can take."
+          buttons={[
+            <Button variant="secondary" size="small">
+              This is a secondary button
+            </Button>,
+            <Button variant="primary" size="small">
+              This is a primary button
+            </Button>,
           ]}
         />
         <InlineAlert
@@ -53,7 +51,7 @@ export default function InlineAlertPage() {
         />
         <InlineAlert
           variant="info"
-          hideIcon={true}
+          isIconHidden={true}
           title="This alert has no icon"
         />
       </div>

--- a/packages/react-components/src/pages/index.ts
+++ b/packages/react-components/src/pages/index.ts
@@ -1,4 +1,5 @@
 import ButtonPage from "./Button";
+import ButtonGroupPage from "./ButtonGroup";
 import InlineAlertPage from "./InlineAlert";
 import SelectPage from "./Select";
 import TagGroupPage from "./TagGroup";
@@ -9,6 +10,7 @@ import TooltipPage from "./Tooltip";
 
 export {
   ButtonPage,
+  ButtonGroupPage,
   InlineAlertPage,
   SelectPage,
   TagGroupPage,

--- a/packages/react-components/src/stories/ButtonGroup.mdx
+++ b/packages/react-components/src/stories/ButtonGroup.mdx
@@ -1,0 +1,26 @@
+{/* ButtonGroup.mdx */}
+
+import {
+  Canvas,
+  Controls,
+  Meta,
+  Primary,
+  Source,
+  Story,
+  Subtitle,
+} from "@storybook/blocks";
+
+import * as ButtonGroupStories from "./ButtonGroup.stories";
+
+<Meta of={ButtonGroupStories} />
+
+# Button group
+
+<Subtitle>Layout component for buttons</Subtitle>
+
+<Source
+  code={`import { ButtonGroup} from "@bcgov/design-system-react-components";`}
+  language="typescript"
+/>
+
+## Usage and resources

--- a/packages/react-components/src/stories/ButtonGroup.mdx
+++ b/packages/react-components/src/stories/ButtonGroup.mdx
@@ -11,6 +11,7 @@ import {
 } from "@storybook/blocks";
 
 import * as ButtonGroupStories from "./ButtonGroup.stories";
+import * as InlineAlertStories from "./InlineAlert.stories";
 
 <Meta of={ButtonGroupStories} />
 
@@ -19,8 +20,43 @@ import * as ButtonGroupStories from "./ButtonGroup.stories";
 <Subtitle>Layout component for buttons</Subtitle>
 
 <Source
-  code={`import { ButtonGroup} from "@bcgov/design-system-react-components";`}
+  code={`import { ButtonGroup } from "@bcgov/design-system-react-components";`}
   language="typescript"
 />
 
 ## Usage and resources
+
+ButtonGroup is a utility component intended for use when multiple buttons need to be rendered alongside one another. It contains basic styling to ensure proper spacing between the buttons.
+
+ButtonGroup renders a `<div>` with the [ARIA "group" role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/group_role). It expects an array of [buttons](/docs/components-button-button--docs), passed via the `children` prop.
+
+### Example
+
+ButtonGroup is used to populate buttons within the [Inline Alert component](/docs/components-inline-alert-inline-alert--docs):
+
+<Canvas of={InlineAlertStories.AlertWithButtons} />
+
+## Controls
+
+<Canvas of={ButtonGroupStories.ButtonGroupTemplate} />
+<Controls of={ButtonGroupStories.ButtonGroupTemplate} />
+
+## Layout
+
+By default, ButtonGroup renders buttons in a horizontal row, starting from the left edge.
+
+### Orientation
+
+Use the `orientation` prop to toggle the orientation of the button group between `horizontal` and `vertical` layouts:
+
+<Canvas of={ButtonGroupStories.VerticalButtonGroup} />
+
+### Alignment
+
+Use the `alignment` prop to set the alignment of the buttons within the group:
+
+- `start` (left or top, depending on orientation)
+- `center`
+- `end` (right or bottom, depending on orentation)
+
+<Canvas of={ButtonGroupStories.CenteredButtonGroup} />

--- a/packages/react-components/src/stories/ButtonGroup.mdx
+++ b/packages/react-components/src/stories/ButtonGroup.mdx
@@ -28,7 +28,7 @@ import * as InlineAlertStories from "./InlineAlert.stories";
 
 ButtonGroup is a utility component intended for use when multiple buttons need to be rendered alongside one another. It contains basic styling to ensure proper spacing between the buttons.
 
-ButtonGroup renders a `<div>` with the [ARIA "group" role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/group_role). It expects an array of [buttons](/docs/components-button-button--docs), passed via the `children` prop.
+ButtonGroup renders a `<div>` with the [ARIA "group" role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/group_role) and a user-defined `aria-label`. It expects an array of [buttons](/docs/components-button-button--docs), passed via the `children` prop.
 
 ### Example
 
@@ -57,6 +57,6 @@ Use the `alignment` prop to set the alignment of the buttons within the group:
 
 - `start` (left or top, depending on orientation)
 - `center`
-- `end` (right or bottom, depending on orentation)
+- `end` (right or bottom, depending on orientation)
 
 <Canvas of={ButtonGroupStories.CenteredButtonGroup} />

--- a/packages/react-components/src/stories/ButtonGroup.mdx
+++ b/packages/react-components/src/stories/ButtonGroup.mdx
@@ -15,7 +15,7 @@ import * as InlineAlertStories from "./InlineAlert.stories";
 
 <Meta of={ButtonGroupStories} />
 
-# Button group
+# ButtonGroup
 
 <Subtitle>Layout component for buttons</Subtitle>
 

--- a/packages/react-components/src/stories/ButtonGroup.stories.tsx
+++ b/packages/react-components/src/stories/ButtonGroup.stories.tsx
@@ -4,7 +4,7 @@ import { Button, ButtonGroup } from "../components";
 import { ButtonGroupProps } from "@/components/ButtonGroup";
 
 const meta = {
-  title: "Components/Button/Button group",
+  title: "Components/Button/ButtonGroup",
   component: ButtonGroup,
   parameters: {
     layout: "centered",

--- a/packages/react-components/src/stories/ButtonGroup.stories.tsx
+++ b/packages/react-components/src/stories/ButtonGroup.stories.tsx
@@ -4,18 +4,47 @@ import { Button, ButtonGroup } from "../components";
 import { ButtonGroupProps } from "@/components/ButtonGroup";
 
 const meta = {
-  title: "Utility/ButtonGroup",
+  title: "Utility/Button group",
   component: ButtonGroup,
   parameters: {
     layout: "centered",
   },
-  argTypes: {},
+  argTypes: {
+    orientation: {
+      options: ["horizontal", "vertical"],
+      control: { type: "radio" },
+      description: "Layout of button group",
+    },
+    "aria-label": {
+      control: { type: "text" },
+      description: "Semantic label for the button group",
+    },
+  },
 } satisfies Meta<typeof ButtonGroup>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const ButtonGroupTemplate: Story = {
-  args: {},
+  args: {
+    orientation: "horizontal",
+    children: [
+      <Button variant="primary">Button 1</Button>,
+      <Button variant="secondary">Button 2</Button>,
+      <Button variant="secondary">Button 3</Button>,
+    ],
+  },
   render: ({ ...args }: ButtonGroupProps) => <ButtonGroup {...args} />,
+};
+
+export const VerticalButtonGroup: Story = {
+  ...ButtonGroupTemplate,
+  args: {
+    orientation: "vertical",
+    children: [
+      <Button variant="primary">Button 1</Button>,
+      <Button variant="secondary">Button 2</Button>,
+      <Button variant="secondary">Button 3</Button>,
+    ],
+  },
 };

--- a/packages/react-components/src/stories/ButtonGroup.stories.tsx
+++ b/packages/react-components/src/stories/ButtonGroup.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
       control: { type: "radio" },
       description: "Alignment of buttons within group",
     },
-    "aria-label": {
+    ariaLabel: {
       control: { type: "text" },
       description: "Semantic label for the button group",
     },
@@ -34,6 +34,7 @@ export const ButtonGroupTemplate: Story = {
   args: {
     alignment: "start",
     orientation: "horizontal",
+    ariaLabel: "A group of buttons",
     children: [
       <Button variant="primary">Button 1</Button>,
       <Button variant="secondary">Button 2</Button>,

--- a/packages/react-components/src/stories/ButtonGroup.stories.tsx
+++ b/packages/react-components/src/stories/ButtonGroup.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Button, ButtonGroup } from "../components";
+import { ButtonGroupProps } from "@/components/ButtonGroup";
+
+const meta = {
+  title: "Utility/ButtonGroup",
+  component: ButtonGroup,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {},
+} satisfies Meta<typeof ButtonGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ButtonGroupTemplate: Story = {
+  args: {},
+  render: ({ ...args }: ButtonGroupProps) => <ButtonGroup {...args} />,
+};

--- a/packages/react-components/src/stories/ButtonGroup.stories.tsx
+++ b/packages/react-components/src/stories/ButtonGroup.stories.tsx
@@ -4,7 +4,7 @@ import { Button, ButtonGroup } from "../components";
 import { ButtonGroupProps } from "@/components/ButtonGroup";
 
 const meta = {
-  title: "Utility/Button group",
+  title: "Components/Button/Button group",
   component: ButtonGroup,
   parameters: {
     layout: "centered",
@@ -13,7 +13,12 @@ const meta = {
     orientation: {
       options: ["horizontal", "vertical"],
       control: { type: "radio" },
-      description: "Layout of button group",
+      description: "Layout of button group as a whole",
+    },
+    alignment: {
+      options: ["start", "center", "end"],
+      control: { type: "radio" },
+      description: "Alignment of buttons within group",
     },
     "aria-label": {
       control: { type: "text" },
@@ -27,6 +32,7 @@ type Story = StoryObj<typeof meta>;
 
 export const ButtonGroupTemplate: Story = {
   args: {
+    alignment: "start",
     orientation: "horizontal",
     children: [
       <Button variant="primary">Button 1</Button>,
@@ -41,6 +47,19 @@ export const VerticalButtonGroup: Story = {
   ...ButtonGroupTemplate,
   args: {
     orientation: "vertical",
+    children: [
+      <Button variant="primary">Button 1</Button>,
+      <Button variant="secondary">Button 2</Button>,
+      <Button variant="secondary">Button 3</Button>,
+    ],
+  },
+};
+
+export const CenteredButtonGroup: Story = {
+  ...ButtonGroupTemplate,
+  args: {
+    orientation: "horizontal",
+    alignment: "center",
     children: [
       <Button variant="primary">Button 1</Button>,
       <Button variant="secondary">Button 2</Button>,

--- a/packages/react-components/src/stories/InlineAlert.mdx
+++ b/packages/react-components/src/stories/InlineAlert.mdx
@@ -80,7 +80,9 @@ Pass `isIconHidden` to hide the theme icon on the left:
 
 <Canvas of={InlineAlertStories.InlineAlertWithoutIcon} />
 
-Alternatively, you can use pass components and content into the `children` slot, replacing the default `title` and `description` pattern with your own composition.
+#### Overriding alert layout
+
+To override the standard `title`, `description` and `buttons` composition, you can pass your own components and content via the `children` slot.
 
 ### Closeable alerts
 

--- a/packages/react-components/src/stories/InlineAlert.mdx
+++ b/packages/react-components/src/stories/InlineAlert.mdx
@@ -72,6 +72,10 @@ Use the `title` and optional `description` props to populate an alert's content:
 
 <Canvas of={InlineAlertStories.InlineAlertTemplate} />
 
+Use the `buttons` prop to pass an array of button components, which are rendered inside a [ButtonGroup](/docs/components-button-button-group--docs):
+
+<Canvas of={InlineAlertStories.AlertWithButtons} />
+
 Pass `isIconHidden` to hide the theme icon on the left:
 
 <Canvas of={InlineAlertStories.InlineAlertWithoutIcon} />

--- a/packages/react-components/src/stories/InlineAlert.mdx
+++ b/packages/react-components/src/stories/InlineAlert.mdx
@@ -68,7 +68,7 @@ If no `variant` prop is passed, the alert defaults to the `info` theme.
 
 ### Alert content
 
-Use the `title` and optional `description` props to populate an alert's content:
+Use the `title` and optional `description` props to populate an alert's content. `title` provides an accessible name for the alert, using [aria-labelledby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby).
 
 <Canvas of={InlineAlertStories.InlineAlertTemplate} />
 

--- a/packages/react-components/src/stories/InlineAlert.stories.tsx
+++ b/packages/react-components/src/stories/InlineAlert.stories.tsx
@@ -112,8 +112,12 @@ export const AlertWithButtons: Story = {
       "It renders a ButtonGroup area, into which you can pass button components.",
     variant: "success",
     buttons: [
-      <Button variant="primary">Button 1</Button>,
-      <Button variant="secondary">Button 2</Button>,
+      <Button variant="primary" size="small">
+        Button 1
+      </Button>,
+      <Button variant="secondary" size="small">
+        Button 2
+      </Button>,
     ],
   },
 };

--- a/packages/react-components/src/stories/InlineAlert.stories.tsx
+++ b/packages/react-components/src/stories/InlineAlert.stories.tsx
@@ -23,6 +23,10 @@ const meta = {
       control: { type: "text" },
       description: "Sets the alert text",
     },
+    buttons: {
+      control: { type: "object" },
+      description: "Expects an array of button components",
+    },
     isIconHidden: {
       control: { type: "boolean" },
       description: "Show or hide the left icon",

--- a/packages/react-components/src/stories/InlineAlert.stories.tsx
+++ b/packages/react-components/src/stories/InlineAlert.stories.tsx
@@ -107,7 +107,6 @@ export const AlertWithButtons: Story = {
     description:
       "It renders a ButtonGroup area, into which you can pass button components",
     variant: "success",
-    isCloseable: true,
     buttons: [
       <Button variant="primary">Button 1</Button>,
       <Button variant="secondary">Button 2</Button>,

--- a/packages/react-components/src/stories/InlineAlert.stories.tsx
+++ b/packages/react-components/src/stories/InlineAlert.stories.tsx
@@ -87,7 +87,7 @@ export const DangerAlert: Story = {
     variant: "danger",
     title: "This is an alert with the 'danger' theme",
     description:
-      "Use this alert theme to communicate an urgent warning or error to the user",
+      "Use this alert theme to communicate an urgent warning or error to the user.",
   },
 };
 
@@ -109,7 +109,7 @@ export const AlertWithButtons: Story = {
   args: {
     title: "This is an alert with additional buttons",
     description:
-      "It renders a ButtonGroup area, into which you can pass button components",
+      "It renders a ButtonGroup area, into which you can pass button components.",
     variant: "success",
     buttons: [
       <Button variant="primary">Button 1</Button>,

--- a/packages/react-components/src/stories/InlineAlert.stories.tsx
+++ b/packages/react-components/src/stories/InlineAlert.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { InlineAlert } from "../components";
+import { InlineAlert, Button } from "../components";
 import { InlineAlertProps } from "@/components/InlineAlert";
 
 const meta = {
@@ -98,5 +98,19 @@ export const CloseableAlert: Story = {
   args: {
     title: "This alert is closeable",
     isCloseable: true,
+  },
+};
+
+export const AlertWithButtons: Story = {
+  args: {
+    title: "This is an alert with additional buttons",
+    description:
+      "It renders a ButtonGroup area, into which you can pass button components",
+    variant: "success",
+    isCloseable: true,
+    buttons: [
+      <Button variant="primary">Button 1</Button>,
+      <Button variant="secondary">Button 2</Button>,
+    ],
   },
 };


### PR DESCRIPTION
This change adds a new `ButtonGroup`, as described in #443. 

ButtonGroup renders a `<div>` with the [ARIA "group" role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/group_role). It expects button components to be passed as `children`.

ButtonGroup has props to configure its layout:

- `orientation` can be set to `horizontal` or `vertical`
- `alignment` can be set to `start`, `center` or `end`

The default layout is a horizontal row, with the buttons pinned to the left side (`orientation="horizontal"`, `alignment="start"`)

[47e8b38](https://github.com/bcgov/design-system/pull/446/commits/47e8b38b7e69d5858594219296ce05df6e864a1a) refactors the Inline Alert component to include a new `buttons` slot. The user can pass an array of button components via this prop, that will then be rendered inside a ButtonGroup. An example story is included in both the ButtonGroup and InlineAlert docs:

<img width="1076" alt="Screenshot 2024-08-12 at 16 48 00" src="https://github.com/user-attachments/assets/eea15804-760d-4cf8-8e49-c1560a412827">

This PR also includes some other minor changes to Inline Alert, primarily focused on the Storybook examples and docs and fixing a broken `aria-labelledby` property ([0c5b596](https://github.com/bcgov/design-system/pull/446/commits/0c5b5966bfde21d2b75eb34ff62f1285bfa25b19))