### PR TITLE
React components library v0.1.2

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,12 +1,20 @@
 # Changelog
 
+## 0.1.2
+
+### Added
+
+- ButtonGroup component
+- InlineAlert component
+- Switch component
+
 ## 0.1.1
 
 ### Changed
 
 - Use `react-aria-components` v1.3.1.
 
-# 0.1.0
+## 0.1.0
 
 This is a milestone release that contains the following components:
 

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -71,10 +71,13 @@ export default function App() {
 | Component               | React Aria Components docs link                            |
 | ----------------------- | ---------------------------------------------------------- |
 | Button                  | https://react-spectrum.adobe.com/react-aria/Button.html    |
+| ButtonGroup             | N/A                                                        |
 | Footer                  | N/A                                                        |
 | Form                    | https://react-spectrum.adobe.com/react-aria/Form.html      |
 | Header                  | N/A                                                        |
+| InlineAlert             | N/A                                                        |
 | Select                  | https://react-spectrum.adobe.com/react-aria/Select.html    |
+| Switch                  | https://react-spectrum.adobe.com/react-aria/Switch.html    |
 | TagGroup, TagList, Tag  | https://react-spectrum.adobe.com/react-aria/TagGroup.html  |
 | TextArea, TextField     | https://react-spectrum.adobe.com/react-aria/TextField.html |
 | Tooltip, TooltipTrigger | https://react-spectrum.adobe.com/react-aria/Tooltip.html   |

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgov/design-system-react-components",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@bcgov/design-tokens": "3.0.0",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "rollup": "rm -rf dist && rollup -c --bundleConfigAsCjs",


### PR DESCRIPTION
This moves `@bcgov/design-system-react-components` to v0.1.2. This code is currently published on npm as v0.1.2-rc1.

v0.1.2 adds the following components:

- ButtonGroup
- InlineAlert
- Switch

Once this PR is merged, I will publish v0.1.2 to npm on the `latest` tag.