### PR TITLE
v0.1.3

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
-## 0.1.2
+## 0.1.3
 
 ### Added
 
 - ButtonGroup component
+
+## 0.1.2
+
+### Added
+
 - InlineAlert component
 - Switch component
 

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgov/design-system-react-components",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@bcgov/design-tokens": "3.0.0",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "rollup": "rm -rf dist && rollup -c --bundleConfigAsCjs",


### PR DESCRIPTION
This moves `@bcgov/design-system-react-components` to v0.1.3.

[v0.1.2](https://www.npmjs.com/package/@bcgov/design-system-react-components/v/0.1.2) was erroneously published without the `next` tag and doesn't include the `ButtonGroup` component. This has been corrected in the Changelog.