### PR TITLE
InlineAlert close button is removed from document flow to center alert text vertically

### DIFF
--- a/packages/react-components/src/components/InlineAlert/InlineAlert.css
+++ b/packages/react-components/src/components/InlineAlert/InlineAlert.css
@@ -35,11 +35,30 @@
   height: var(--icons-size-medium);
 }
 
-/* Close icon button */
+/* Closeable */
+.bcds-Inline-Alert.closeable {
+  /*
+    Because the close icon button is removed from the document flow, we
+    manually adjust the padding to push the `--container` element off the right
+    edge of the InlineAlert.
+  */
+  padding: var(--layout-padding-medium) 52px var(--layout-padding-medium)
+    var(--layout-padding-large);
+}
+
 .bcds-Inline-Alert--closeIcon {
-  display: inline-flex;
   align-self: first baseline;
   color: var(--icons-color-primary);
+  position: relative;
+}
+
+.bcds-Inline-Alert--closeIcon > button {
+  position: absolute;
+  /*
+    Centers the button vertically.
+    Button height (32px) minus line-height of text (27px) divided by 2.
+  */
+  top: -2.5px;
 }
 
 .bcds-Inline-Alert--closeIcon > svg {

--- a/packages/react-components/src/components/InlineAlert/InlineAlert.tsx
+++ b/packages/react-components/src/components/InlineAlert/InlineAlert.tsx
@@ -57,7 +57,10 @@ export default function InlineAlert({
   ...props
 }: InlineAlertProps) {
   return (
-    <div className={`bcds-Inline-Alert ${variant}`} {...props}>
+    <div
+      className={`bcds-Inline-Alert ${variant} ${isCloseable ? "closeable" : null}`}
+      {...props}
+    >
       {!isIconHidden && (
         <span className="bcds-Inline-Alert--icon">{getIcon(variant)}</span>
       )}


### PR DESCRIPTION
Marking this as a draft so we can discuss whether we prefer to go this route or to make a smaller version of `Button`. See #444.

This PR updates the `InlineAlert` to remove the close button from the document flow, positioning it with `position: absolute` and a negative `top` value to center it.

The advantage of this approach is that we retain the 32px x 32px click target size for the close button, rather than rolling a smaller button. The disadvantage is that the code is more hacky and less declarative than using a smaller button and keeping the current `InlineAlert` code.

Single line of text, before and after:
<img width="1840" alt="Single line, before" src="https://github.com/user-attachments/assets/c87096b0-7f00-44f7-a6ed-8725f1af9ce4">
<img width="1840" alt="Single line, after" src="https://github.com/user-attachments/assets/816f8bee-1707-45db-9bc1-dadf5510f8ce">

Multiple lines of text, before and after:
<img width="1840" alt="Multi line, before" src="https://github.com/user-attachments/assets/5bc321ad-2e2c-4b98-961e-ec58c3d05035">
<img width="1840" alt="Multi line, after" src="https://github.com/user-attachments/assets/7bcaa6da-e92e-4898-a0bd-1464b1571284">
