### PR TITLE
Add GitHub Actions workflow to publish design tokens library to npm

### DIFF
--- a/.github/workflows/publish_design_tokens.yaml
+++ b/.github/workflows/publish_design_tokens.yaml
@@ -1,0 +1,73 @@
+name: Publish @bcgov/design-tokens to npm @next
+
+on:
+  pull_request:
+    paths:
+      - packages/design-tokens/**
+    branches: [main]
+    types: [closed]
+
+jobs:
+  publish-design-tokens:
+    name: Publish @bcgov/design-tokens@next
+    # Only run on merge, not close without merge AND
+    # only run in bcgov/design-system repo, not forks.
+    if: ${{ github.event.pull_request.merged == true && github.repository == 'bcgov/design-system' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Read .nvmrc
+        run: echo "GITHUB_NVMRC_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV
+        working-directory: ./packages/design-tokens
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.GITHUB_NVMRC_VERSION }}
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: ./packages/design-tokens
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      # Use `jq` to change the package.json version to look like:
+      #
+      #   <version in package.json>-pr<PR # that caused the workflow run>
+      #
+      # So package.json version v1.2.3 with a run caused by merging PR #456 to
+      # `main` causes the version of the package on npm to look like:
+      #
+      #   1.2.3-pr456
+      #
+      # This is to ensure that it's easy to map an npm version to a particular PR.
+      #
+      - name: Update version in package.json
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          CURRENT_VERSION=$(jq -r '.version' package.json)
+          NEW_VERSION="${CURRENT_VERSION}-pr${PR_NUMBER}"
+          jq --arg new_version "$NEW_VERSION" '.version = $new_version' package.json > tmp.json && mv tmp.json package.json
+        shell: bash
+        working-directory: ./packages/design-tokens
+
+      - name: Run build script
+        run: npm run build
+        working-directory: ./packages/design-tokens
+
+      - name: Prepare npm package for publishing
+        run: npm run prepare-npm-package
+        working-directory: ./packages/design-tokens
+
+      - name: Set up .npmrc configuration
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+
+      - name: Publish to npm with @next tag
+        run: npm run publish-npm-package -- --tag next
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        working-directory: ./packages/design-tokens


### PR DESCRIPTION
This adds a GitHub Actions workflow file to publish a new version of the `@bcgov/design-tokens` library to npm on the `next` tag when a PR is merged that updates files in `packages/design-tokens`. This mirrors the behaviour of the React components library, giving us a new release candidate to test from npm on each merge. Adding new production versions to the default `latest` tag remains a manual step.