### PR TITLE
Design tokens publish workflow targets package.json in dist directory

### DIFF
--- a/.github/workflows/publish_design_tokens.yaml
+++ b/.github/workflows/publish_design_tokens.yaml
@@ -46,14 +46,14 @@ jobs:
       #
       # This is to ensure that it's easy to map an npm version to a particular PR.
       #
-      - name: Update version in package.json
+      - name: Update version in dist/package.json
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
           CURRENT_VERSION=$(jq -r '.version' package.json)
           NEW_VERSION="${CURRENT_VERSION}-pr${PR_NUMBER}"
           jq --arg new_version "$NEW_VERSION" '.version = $new_version' package.json > tmp.json && mv tmp.json package.json
         shell: bash
-        working-directory: ./packages/design-tokens
+        working-directory: ./packages/design-tokens/dist
 
       - name: Run build script
         run: npm run build


### PR DESCRIPTION
This attempts to fix [this failing workflow run](https://github.com/bcgov/design-system/actions/runs/10461303791) by targeting the `package.json` version within the design tokens `./dist` directory, which is the file that gets published to npm, as opposed to the `package.json` file in the design tokens root directory that is responsible for putting the tokens data through the transformation pipeline.