### PR TITLE
Update design tokens package scripts for CI

### DIFF
--- a/packages/design-tokens/README.md
+++ b/packages/design-tokens/README.md
@@ -18,12 +18,11 @@ See `dist/README.md` for how to use the design tokens in your project.
 
 ## Steps to update and publish tokens
 
-1. Update token data in the JSON file `input/tokens.json`.
+1. Update token data in the JSON file `input/tokens.json` and the `version` field in `./package.json`.
 2. Manually update composite tokens to include parent category. Ex: `{fontWeights.regular}` must become `{typography.fontWeights.regular}`.
 3. Run `npm run build` to run Style Dictionary, transforming the raw JSON data into usable token formats.
-4. Run `npm run prepare-npm-package` to copy the contents of `build` into `dist`.
-5. Manually update the package version in `dist/package.json`.
-6. Run `npm run publish-npm-package` to publish the contents of `dist` to npm.
+4. [Ensure `jq` is installed](https://jqlang.github.io/jq/) on your system and then run `npm run prepare-npm-package` to copy the contents of `build` into `dist`.
+5. Run `npm run publish-npm-package` to publish the contents of `dist` to npm (defaults to using the `latest` tag). If publishing to the pre-release `next` tag, use `npm run publish-npm-package -- --tag next`.
 
 ## Test the build script
 

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "./run-build.sh",
     "prepare-npm-package": "./run-prepare-npm-package.sh",
-    "publish-npm-package": "cd dist && npm publish --access public",
+    "publish-npm-package": "./run-publish-npm-package.sh",
     "test": "node --test build-output.test.js"
   },
   "type": "module",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0",
   "description": "Transformation pipeline for design tokens for B.C. Design System",
   "scripts": {
-    "build": "rm -rf build/cjs* && rm -rf build/css* && rm -rf build/js* && node build-output.js",
+    "build": "./run-build.sh",
     "prepare-npm-package": "rm -rf dist/cjs* && rm -rf dist/css* && rm -rf dist/js* && cp -R build/* dist",
     "publish-npm-package": "cd dist && npm publish --access public",
     "test": "node --test build-output.test.js"

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -4,7 +4,7 @@
   "description": "Transformation pipeline for design tokens for B.C. Design System",
   "scripts": {
     "build": "./run-build.sh",
-    "prepare-npm-package": "rm -rf dist/cjs* && rm -rf dist/css* && rm -rf dist/js* && cp -R build/* dist",
+    "prepare-npm-package": "./run-prepare-npm-package.sh",
     "publish-npm-package": "cd dist && npm publish --access public",
     "test": "node --test build-output.test.js"
   },

--- a/packages/design-tokens/run-build.sh
+++ b/packages/design-tokens/run-build.sh
@@ -1,0 +1,7 @@
+# Remove existing build target directories
+rm -rf build/cjs*
+rm -rf build/css*
+rm -rf build/js*
+
+# Run the tokens transformation script
+node build-output.js

--- a/packages/design-tokens/run-build.sh
+++ b/packages/design-tokens/run-build.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Remove existing build target directories
 rm -rf build/cjs*
 rm -rf build/css*

--- a/packages/design-tokens/run-prepare-npm-package.sh
+++ b/packages/design-tokens/run-prepare-npm-package.sh
@@ -1,0 +1,7 @@
+# Remove existing dist target directories
+rm -rf dist/cjs*
+rm -rf dist/css*
+rm -rf dist/js*
+
+# Copy the contents of build into dist
+cp -R build/* dist

--- a/packages/design-tokens/run-prepare-npm-package.sh
+++ b/packages/design-tokens/run-prepare-npm-package.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Remove existing dist target directories
 rm -rf dist/cjs*
 rm -rf dist/css*

--- a/packages/design-tokens/run-prepare-npm-package.sh
+++ b/packages/design-tokens/run-prepare-npm-package.sh
@@ -5,3 +5,7 @@ rm -rf dist/js*
 
 # Copy the contents of build into dist
 cp -R build/* dist
+
+# Update the version in dist/package.json to match the root package.json version
+ROOT_VERSION=$(jq -r '.version' package.json)
+jq --arg version "$ROOT_VERSION" '.version = $version' dist/package.json > tmp.$$.json && mv tmp.$$.json dist/package.json

--- a/packages/design-tokens/run-publish-npm-package.sh
+++ b/packages/design-tokens/run-publish-npm-package.sh
@@ -1,0 +1,5 @@
+# The dist directory is used as the root for the published design tokens package
+cd dist
+
+# Publish to npm using any extra command line arguments passed to this script
+npm publish "$@"

--- a/packages/design-tokens/run-publish-npm-package.sh
+++ b/packages/design-tokens/run-publish-npm-package.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # The dist directory is used as the root for the published design tokens package
 cd dist
 


### PR DESCRIPTION
This PR updates the scripts in the `packages/design-tokens/package.json` file to make the scripts work better with our GitHub Actions CI environment.

The scripts work the same with the exception of the `prepare-npm-package` script, which now includes an additional step to copy the latest `package.json` version field into the `dist/package.json` file that gets distributed on npm. This requires `jq` to be installed on a developer's machine when running locally, but our GitHub Actions workflow file to publish new design token packages already includes a step to install `jq`.