### PR TITLE
Design tokens publish workflow uses access public flag

### DIFF
--- a/.github/workflows/publish_design_tokens.yaml
+++ b/.github/workflows/publish_design_tokens.yaml
@@ -67,7 +67,7 @@ jobs:
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
 
       - name: Publish to npm with @next tag
-        run: npm run publish-npm-package -- --tag next
+        run: npm run publish-npm-package -- --access public --tag next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: ./packages/design-tokens


### PR DESCRIPTION
This adds the `--access public` flag to the `npm publish` script in the design tokens GitHub Actions workflow to publish release candidate versions to npm. This is to try fixing the 404 error coming from the job in this run: https://github.com/bcgov/design-system/actions/runs/10462466856/job/28972746893