### PR TITLE
Bump @bcgov/design-tokens to v3.1.1

### DIFF
--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bcgov/design-tokens": "3.1.0",
+        "@bcgov/design-tokens": "3.1.1",
         "react-aria-components": "1.3.3"
       },
       "devDependencies": {
@@ -2155,9 +2155,9 @@
       "peer": true
     },
     "node_modules/@bcgov/design-tokens": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@bcgov/design-tokens/-/design-tokens-3.1.0.tgz",
-      "integrity": "sha512-GNkzsdMqSSv9O0/a9+/39XsNxB45YKjIltl8Rn2Co0DSLZk+bKJJOxvo0F5d0ZYAxW0sSjMREMv4GoXFOJDSZw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@bcgov/design-tokens/-/design-tokens-3.1.1.tgz",
+      "integrity": "sha512-b+7O0SQmqVez6lBL9TBTdWSMLgMRscuuBUaKT0ihR/LloKpnkGFgepoM8P14jNyK4ROn8SdoJv/fhR2FEW7Hug==",
       "license": "Apache-2.0"
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -23,7 +23,7 @@
   ],
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@bcgov/design-tokens": "3.1.0",
+    "@bcgov/design-tokens": "3.1.1",
     "react-aria-components": "1.3.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
This bumps the React component library's version of `@bcgov/design-tokens` to v3.1.1.