### PR TITLE
Change button style in inline alert example

### DIFF
--- a/packages/react-components/src/stories/InlineAlert.stories.tsx
+++ b/packages/react-components/src/stories/InlineAlert.stories.tsx
@@ -112,7 +112,7 @@ export const AlertWithButtons: Story = {
       "It renders a ButtonGroup area, into which you can pass button components.",
     variant: "success",
     buttons: [
-      <Button variant="primary" size="small">
+      <Button variant="tertiary" size="small">
         Button 1
       </Button>,
       <Button variant="secondary" size="small">


### PR DESCRIPTION
This PR makes a small tweak to one of the `InlineAlert` examples in Storybook, changing the style of the buttons used at @Philip-Cheung's request.

Before:
<img width="1032" alt="Screenshot 2024-08-27 at 14 37 06" src="https://github.com/user-attachments/assets/e946a96c-aed1-472d-b6e3-6886a8c0cb89">

After:
![Screenshot 2024-08-27 at 14 39 19](https://github.com/user-attachments/assets/a8eff065-45c2-46b0-ab75-606f1de52f37)
