### PR TITLE
Unit tests for Header, Footer, Form, InlineAlert, Switch

### DIFF
--- a/packages/react-components/src/components/Footer/Footer.test.tsx
+++ b/packages/react-components/src/components/Footer/Footer.test.tsx
@@ -1,0 +1,16 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+import Footer from "./Footer";
+
+describe("Footer", () => {
+  render(<Footer />);
+
+  // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/contentinfo_role
+  const contentInfoElements = screen.getAllByRole("contentinfo");
+
+  it("renders an HTML footer component", () => {
+    expect(contentInfoElements).toHaveLength(1);
+    expect(contentInfoElements[0].tagName).toBe("FOOTER");
+  });
+});

--- a/packages/react-components/src/components/Footer/Footer.tsx
+++ b/packages/react-components/src/components/Footer/Footer.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import SvgBcLogo from "../Icons/SvgBcLogo";
 
 import "./Footer.css";

--- a/packages/react-components/src/components/Form/Form.test.tsx
+++ b/packages/react-components/src/components/Form/Form.test.tsx
@@ -1,0 +1,14 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+import Form from "./Form";
+
+describe("Form", () => {
+  render(<Form data-testid="form-element" />);
+
+  const form = screen.getByTestId("form-element");
+
+  it("renders an HTML form component", () => {
+    expect(form.tagName).toBe("FORM");
+  });
+});

--- a/packages/react-components/src/components/Header/Header.test.tsx
+++ b/packages/react-components/src/components/Header/Header.test.tsx
@@ -1,0 +1,16 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+import Header from "./Header";
+
+describe("Header", () => {
+  render(<Header />);
+
+  // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/banner_role
+  const bannerElements = screen.getAllByRole("banner");
+
+  it("renders an HTML header component", () => {
+    expect(bannerElements).toHaveLength(1);
+    expect(bannerElements[0].tagName).toBe("HEADER");
+  });
+});

--- a/packages/react-components/src/components/Header/Header.tsx
+++ b/packages/react-components/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { cloneElement, PropsWithChildren } from "react";
 
 import SvgBcLogo from "../Icons/SvgBcLogo";
 
@@ -38,7 +38,7 @@ export default function Header({
   skipLinks,
   title = "",
   titleElement = "span",
-}: React.PropsWithChildren<HeaderProps>) {
+}: PropsWithChildren<HeaderProps>) {
   function getLogo() {
     if (!logoLinkElement)
       return (
@@ -47,7 +47,7 @@ export default function Header({
         </a>
       );
 
-    return React.cloneElement(logoLinkElement, { children: logoImage });
+    return cloneElement(logoLinkElement, { children: logoImage });
   }
 
   function getTitle() {

--- a/packages/react-components/src/components/InlineAlert/InlineAlert.test.tsx
+++ b/packages/react-components/src/components/InlineAlert/InlineAlert.test.tsx
@@ -1,0 +1,37 @@
+import "@testing-library/jest-dom";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import InlineAlert from "./InlineAlert";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("InlineAlert", () => {
+  it("renders a div with role='note'", () => {
+    render(<InlineAlert variant="info" data-testid="info" />);
+    render(<InlineAlert variant="danger" data-testid="danger" />);
+    render(<InlineAlert variant="success" data-testid="success" />);
+    render(<InlineAlert variant="warning" data-testid="warning" />);
+
+    const alertElements = screen.getAllByRole("note");
+
+    expect(alertElements).toHaveLength(4);
+    expect(alertElements[0].tagName).toBe("DIV");
+  });
+
+  it("isCloseable prop causes a close button to be rendered", () => {
+    const handleClose = jest.fn();
+    render(
+      <InlineAlert isCloseable onClose={handleClose} data-test-id="closeable" />
+    );
+
+    const closeButtons = screen.getAllByRole("button");
+
+    expect(closeButtons[0]).toHaveAccessibleName(/close this alert/i);
+
+    fireEvent.click(closeButtons[0]);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-components/src/components/InlineAlert/InlineAlert.tsx
+++ b/packages/react-components/src/components/InlineAlert/InlineAlert.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 import Button from "../Button";
 import ButtonGroup from "../ButtonGroup";
 import SvgCheckCircleIcon from "../Icons/SvgCheckCircleIcon";

--- a/packages/react-components/src/components/Select/Select.tsx
+++ b/packages/react-components/src/components/Select/Select.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   Button,
   Collection,

--- a/packages/react-components/src/components/Switch/Switch.test.tsx
+++ b/packages/react-components/src/components/Switch/Switch.test.tsx
@@ -1,0 +1,39 @@
+import "@testing-library/jest-dom";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import Switch from "./Switch";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Switch", () => {
+  it("renders an HTML input component", () => {
+    render(<Switch>Flip me</Switch>);
+
+    const switchElements = screen.getAllByLabelText(/flip me/i);
+
+    expect(switchElements).toHaveLength(1);
+    expect(switchElements[0].tagName).toBe("INPUT");
+    expect(switchElements[0]).toHaveAccessibleName(/flip me/i);
+  });
+
+  it("onChange handler fires on click", () => {
+    const handleChange = jest.fn();
+    render(<Switch onChange={handleChange}>Power</Switch>);
+
+    const switchElement = screen.getByLabelText(/power/i);
+
+    fireEvent.click(switchElement);
+
+    expect(handleChange).toHaveBeenCalled();
+  });
+
+  it("defaultSelected adds checked attribute", () => {
+    render(<Switch defaultSelected>Standby</Switch>);
+
+    const switchElement = screen.getByLabelText(/standby/i);
+
+    expect(switchElement).toHaveAttribute("checked");
+  });
+});


### PR DESCRIPTION
This adds unit tests for:

- Header f3b36c2e3a7e1ff721a670d6cd759e85464329e1
- Footer 849216f71b322b768567506709668ed97c496339
- Form 7066f14ac50aa55ad2f73db0c2defb2a989147a8
- InlineAlert 30d8e27780948de921e31876833fdea555265b9d
- Switch c43e32c652ffa992778d0a6cd8239c277e4b5217

I found that some existing default React import statements (`import React from "react"`) caused tests to not run. In cases where we were using methods on the `React` object, I have explicitly kept those imports. In cases where we were only using `React` for type information, I have removed the default import statement. This shouldn't make any difference - it's just to keep the TypeScript compiler happy. @mkernohanbc you had mentioned this in #450 and at that time, I couldn't remove the import statement without the compiler complaining on those `React.ReactElement` type fields. We haven't changed our `tsconfig.json` file, so I'm thinking something may have changed in one of the underlying devDependencies. 🤷‍♂️ 

Speaking of the TypeScript compiler, I find I can't add a test file for the Select component because of implicit types that the Jest test runner feels are missing:

<img width="1838" alt="Jest output for Select test" src="https://github.com/user-attachments/assets/dccde573-bf17-4e8e-b445-c04c934c73a2">

I'm not sure what the best way to fix that is yet, so there's no test file added for Select in this PR.

All tests should be passing in this PR.