### PR TITLE
React components v0.2.0

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.2.0
+
+This is a milestone release that contains the following new components:
+
+- ButtonGroup
+- InlineAlert
+- Switch
+
+This release uses:
+
+- `react-aria-components` v1.3.3
+- `@bcgov/design-tokens`v3.1.1
+
+No component changes from v0.1.4.
+
 ## 0.1.4
 
 ### Changed

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgov/design-system-react-components",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@bcgov/design-tokens": "3.1.1",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "rollup": "rm -rf dist && rollup -c --bundleConfigAsCjs",


### PR DESCRIPTION
This PR represents a milestone release of `@bcgov/design-system-react-components` at v0.2.0.

New components added in this release:

- ButtonGroup
- InlineAlert
- Switch

Dependencies:

- `react-aria-components` v1.3.3
- `@bcgov/design-tokens`v3.1.1

This version of the code is available now for testing on npm on the `next` tag as v0.2.0-rc1: https://www.npmjs.com/package/@bcgov/design-system-react-components/v/0.2.0-rc1