### PR TITLE
Component cleanup

### DIFF
--- a/packages/react-components/src/components/Form/Form.tsx
+++ b/packages/react-components/src/components/Form/Form.tsx
@@ -3,8 +3,6 @@ import {
   FormProps as ReactAriaFormProps,
 } from "react-aria-components";
 
-export type FormProps = ReactAriaFormProps;
-
-export default function Form({ ...props }: FormProps) {
+export default function Form({ ...props }: ReactAriaFormProps) {
   return <ReactAriaForm {...props} />;
 }

--- a/packages/react-components/src/components/Form/index.ts
+++ b/packages/react-components/src/components/Form/index.ts
@@ -1,2 +1,2 @@
 export { default } from "./Form";
-export type { FormProps } from "./Form";
+export type { FormProps } from "react-aria-components";

--- a/packages/react-components/src/components/Icons/SvgTooltipArrowUp/SvgTooltipArrowUp.tsx
+++ b/packages/react-components/src/components/Icons/SvgTooltipArrowUp/SvgTooltipArrowUp.tsx
@@ -1,0 +1,18 @@
+export default function SvgTooltipArrowUp({ id = "tooltip-arrow" }) {
+  return (
+    <svg
+      id={id}
+      width="19"
+      height="9"
+      viewBox="0 0 19 9"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g>
+        <path
+          d="M8.4188 1.41421C9.19985 0.633163 10.4662 0.633165 11.2472 1.41421L18.833 9L0.833008 9L8.4188 1.41421Z"
+          fill="currentColor"
+        />
+      </g>
+    </svg>
+  );
+}

--- a/packages/react-components/src/components/Icons/SvgTooltipArrowUp/index.ts
+++ b/packages/react-components/src/components/Icons/SvgTooltipArrowUp/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SvgTooltipArrowUp";

--- a/packages/react-components/src/components/Switch/Switch.tsx
+++ b/packages/react-components/src/components/Switch/Switch.tsx
@@ -6,7 +6,6 @@ import {
 import "./Switch.css";
 
 export interface SwitchProps extends ReactAriaSwitchProps {
-  children?: React.ReactNode;
   /* Label positioning relative to switch */
   labelPosition?: "left" | "right";
 }

--- a/packages/react-components/src/components/TextField/TextField.css
+++ b/packages/react-components/src/components/TextField/TextField.css
@@ -123,7 +123,9 @@
   color: var(--typography-color-danger);
 }
 
-.bcds-react-aria-TextField--container > .iconError {
+.bcds-react-aria-TextField[data-invalid]
+  > .bcds-react-aria-TextField--container
+  > svg#exclamation-icon {
   color: var(--icons-color-danger);
   min-width: var(--icons-size-medium);
   height: var(--icons-size-medium);

--- a/packages/react-components/src/components/TextField/TextField.css
+++ b/packages/react-components/src/components/TextField/TextField.css
@@ -122,3 +122,9 @@
   font: var(--typography-regular-small-body);
   color: var(--typography-color-danger);
 }
+
+.bcds-react-aria-TextField--container > .iconError {
+  color: var(--icons-color-danger);
+  min-width: var(--icons-size-medium);
+  height: var(--icons-size-medium);
+}

--- a/packages/react-components/src/components/TextField/TextField.tsx
+++ b/packages/react-components/src/components/TextField/TextField.tsx
@@ -54,11 +54,7 @@ export default function TextField({
           >
             {iconLeft}
             <Input className="bcds-react-aria-TextField--Input" />
-            {isInvalid && (
-              <div className="iconError">
-                <SvgExclamationIcon />
-              </div>
-            )}
+            {isInvalid && <SvgExclamationIcon />}
             {iconRight}
           </div>
           {description && (

--- a/packages/react-components/src/components/TextField/TextField.tsx
+++ b/packages/react-components/src/components/TextField/TextField.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-aria-components";
 
 import "./TextField.css";
+import SvgExclamationIcon from "../Icons/SvgExclamationIcon";
 
 export interface TextFieldProps extends ReactAriaTextFieldProps {
   /* Sets size of text input field */
@@ -24,24 +25,6 @@ export interface TextFieldProps extends ReactAriaTextFieldProps {
   /* Icon slot to right of text input field */
   iconRight?: React.ReactElement;
 }
-
-/* Icon displayed when input is in invalid state */
-const iconError = (
-  <svg
-    width="20"
-    height="20"
-    viewBox="0 0 20 20"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <g id="20px/Error icon">
-      <path
-        id="Icon"
-        d="M17.835 15.0312C18.335 15.9062 17.71 17 16.6787 17H3.33499C2.30374 17 1.67874 15.9062 2.14749 15.0312L8.83499 3.65625C9.11624 3.21875 9.55373 3 10.0225 3C10.46 3 10.8975 3.21875 11.1787 3.65625L17.835 15.0312ZM3.64749 15.5H16.3663L9.99123 4.65625L3.64749 15.5ZM10.0225 12.5625C10.5537 12.5625 10.9912 13 10.9912 13.5312C10.9912 14.0625 10.5537 14.5 10.0225 14.5C9.45998 14.5 9.02249 14.0625 9.02249 13.5312C9.02249 13 9.45998 12.5625 10.0225 12.5625ZM9.27249 7.75C9.27249 7.34375 9.58498 7 10.0225 7C10.4287 7 10.7725 7.34375 10.7725 7.75V10.75C10.7725 11.1875 10.4287 11.5 10.0225 11.5C9.58498 11.5 9.27249 11.1875 9.27249 10.75V7.75Z"
-        fill="var(--icons-color-danger)"
-      />
-    </g>
-  </svg>
-);
 
 export default function TextField({
   size,
@@ -71,7 +54,11 @@ export default function TextField({
           >
             {iconLeft}
             <Input className="bcds-react-aria-TextField--Input" />
-            {isInvalid && iconError}
+            {isInvalid && (
+              <div className="iconError">
+                <SvgExclamationIcon />
+              </div>
+            )}
             {iconRight}
           </div>
           {description && (

--- a/packages/react-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react-components/src/components/Tooltip/Tooltip.tsx
@@ -6,24 +6,7 @@ import {
 } from "react-aria-components";
 
 import "./Tooltip.css";
-
-// This tooltip arrow is available as a plain SVG at src/assets/tooltip-arrow-up.svg
-function SvgTooltipArrowUp() {
-  return (
-    <svg
-      width="19"
-      height="9"
-      viewBox="0 0 19 9"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M8.4188 1.41421C9.19985 0.633163 10.4662 0.633165 11.2472 1.41421L18.833 9L0.833008 9L8.4188 1.41421Z"
-        fill="currentColor"
-      />
-    </svg>
-  );
-}
+import SvgTooltipArrowUp from "../Icons/SvgTooltipArrowUp";
 
 export default function Tooltip(props: TooltipProps) {
   return (

--- a/packages/react-components/src/components/index.ts
+++ b/packages/react-components/src/components/index.ts
@@ -15,6 +15,7 @@ export { default as SvgChevronUpIcon } from "./Icons/SvgChevronUpIcon";
 export { default as SvgChevronDownIcon } from "./Icons/SvgChevronDownIcon";
 export { default as SvgCloseIcon } from "./Icons/SvgCloseIcon";
 export { default as SvgInfoIcon } from "./Icons/SvgInfoIcon";
+export { default as SvgTooltipArrowUp } from "./Icons/SvgTooltipArrowUp";
 export { default as Tag } from "./Tag";
 export { default as TagGroup } from "./TagGroup";
 export { default as TagList } from "./TagList";

--- a/packages/react-components/src/stories/Switch.stories.tsx
+++ b/packages/react-components/src/stories/Switch.stories.tsx
@@ -10,6 +10,10 @@ const meta = {
     layout: "centered",
   },
   argTypes: {
+    children: {
+      control: { type: "object" },
+      description: "Used to set label text",
+    },
     labelPosition: {
       options: ["left", "right"],
       control: { type: "radio" },


### PR DESCRIPTION
This PR aggregates a bunch of small revisions and cleanup to various components:

- 3856d96 (TextField) and efa9158 (Tooltip): remove icon instantiation from components, use SVG icon components instead  
- 0b0a1b712b1b160dbf144c2e4f869fa9a54aba4e (Switch) and 76b285cc766612e0a4ce985b18a94f295bd54102 (Form): clean up redundant or unnecessary prop declarations

None of these commits make visible or functionality changes to components.