### PR TITLE
Add Vite build to React component library GHA test workflow

### DIFF
--- a/.github/workflows/test_react_component_library.yaml
+++ b/.github/workflows/test_react_component_library.yaml
@@ -38,8 +38,15 @@ jobs:
         run: npm run lint
         working-directory: ./packages/react-components
 
-      - name: Run test suite with npm script
+      - name: Run test suite
         run: npm run test:ci
+        working-directory: ./packages/react-components
+
+      # Treat failures in the Vite build as test failures.
+      # We don't need to keep the artifact of this build,
+      # we just care that it completes successfully.
+      - name: Run Vite build
+        run: npm run vite-build
         working-directory: ./packages/react-components
 
   playwright-accessibility-tests:


### PR DESCRIPTION
This adds the Vite build script to the React component library's GitHub Actions workflow for running tests.

In this case, we don't care about the artifacts that the build script produces - we just want to make sure the build itself is going to complete because it is preferable to figure out that a build will fail prior to merging the code.