### PR TITLE
Checkbox index file exports CheckboxProps from React Aria Components

### DIFF
--- a/packages/react-components/src/components/Checkbox/index.ts
+++ b/packages/react-components/src/components/Checkbox/index.ts
@@ -1,2 +1,2 @@
 export { default } from "./Checkbox";
-export type { CheckboxProps } from "./Checkbox";
+export type { CheckboxProps } from "react-aria-components";


### PR DESCRIPTION
[This broken GitHub Actions job](https://github.com/bcgov/design-system/actions/runs/10816731111/job/30008521842) is caused by a missing TypeScript interface that I removed in https://github.com/bcgov/design-system/commit/9cb5205ea4d7ce730d3f4dea506d29b210ab9a39.

The fix in this PR changes the export statement to use the React Aria Component `CheckboxProps` interface straight from the RAC package.