### PR TITLE
React components v0.2.2

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.2
+
+### Added
+
+- Added CheckboxGroup/Checkbox components.
+
 ## 0.2.1
 
 No changes from v0.2.0.

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -68,19 +68,21 @@ export default function App() {
 
 ## Component list
 
-| Component               | React Aria Components docs link                            |
-| ----------------------- | ---------------------------------------------------------- |
-| Button                  | https://react-spectrum.adobe.com/react-aria/Button.html    |
-| ButtonGroup             | N/A                                                        |
-| Footer                  | N/A                                                        |
-| Form                    | https://react-spectrum.adobe.com/react-aria/Form.html      |
-| Header                  | N/A                                                        |
-| InlineAlert             | N/A                                                        |
-| Select                  | https://react-spectrum.adobe.com/react-aria/Select.html    |
-| Switch                  | https://react-spectrum.adobe.com/react-aria/Switch.html    |
-| TagGroup, TagList, Tag  | https://react-spectrum.adobe.com/react-aria/TagGroup.html  |
-| TextArea, TextField     | https://react-spectrum.adobe.com/react-aria/TextField.html |
-| Tooltip, TooltipTrigger | https://react-spectrum.adobe.com/react-aria/Tooltip.html   |
+| Component               | React Aria Components docs link                                |
+| ----------------------- | -------------------------------------------------------------- |
+| Button                  | https://react-spectrum.adobe.com/react-aria/Button.html        |
+| ButtonGroup             | N/A                                                            |
+| Checkbox                | https://react-spectrum.adobe.com/react-aria/Checkbox.html      |
+| CheckboxGroup           | https://react-spectrum.adobe.com/react-aria/CheckboxGroup.html |
+| Footer                  | N/A                                                            |
+| Form                    | https://react-spectrum.adobe.com/react-aria/Form.html          |
+| Header                  | N/A                                                            |
+| InlineAlert             | N/A                                                            |
+| Select                  | https://react-spectrum.adobe.com/react-aria/Select.html        |
+| Switch                  | https://react-spectrum.adobe.com/react-aria/Switch.html        |
+| TagGroup, TagList, Tag  | https://react-spectrum.adobe.com/react-aria/TagGroup.html      |
+| TextArea, TextField     | https://react-spectrum.adobe.com/react-aria/TextField.html     |
+| Tooltip, TooltipTrigger | https://react-spectrum.adobe.com/react-aria/Tooltip.html       |
 
 ## Supported React versions
 

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgov/design-system-react-components",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@bcgov/design-tokens": "3.1.1",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "rollup": "rm -rf dist && rollup -c --bundleConfigAsCjs",


### PR DESCRIPTION
This bumps @bcgov/design-system-react-components to v0.2.2. This code is currently published on npm on the `next` tag as v0.2.2-rc1.

# Changelog

## 0.2.2

### Added

- Added CheckboxGroup/Checkbox components.