### PR TITLE
Switch animation obeys prefers-reduced-motion

### DIFF
--- a/packages/react-components/src/components/Switch/Switch.css
+++ b/packages/react-components/src/components/Switch/Switch.css
@@ -16,6 +16,12 @@
   border-radius: var(--icons-size-medium);
   transition: all 200ms;
 }
+@media (prefers-reduced-motion) {
+  /* No animation on Switch container color if user has reduced motion set */
+  .bcds-react-aria-Switch > .indicator {
+    transition: none;
+  }
+}
 
 /* Indicator */
 .bcds-react-aria-Switch > .indicator::before {
@@ -29,6 +35,12 @@
     var(--surface-color-border-medium);
   border-radius: var(--icons-size-small);
   transition: all 200ms;
+}
+@media (prefers-reduced-motion) {
+  /* No animation on Switch circle indicator if user has reduced motion set */
+  .bcds-react-aria-Switch > .indicator::before {
+    transition: none;
+  }
 }
 
 /* Selected */


### PR DESCRIPTION
This updates the Switch component to add [`prefers-reduced-motion` rules](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) to its `transition` style rules. This has the effect of removing the animation when a user has set up their browser (or OS) to reduce the amount of motion they see.

See [MDN's prefers-reduced-motion User Preferences](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion#user_preferences) for instructions on changing this setting to test.

Chrome in macOS with "Reduce motion" turned on:
https://github.com/user-attachments/assets/0fde3d9e-203b-4ec1-9f19-21540cc4aeda

Turned off (default):
https://github.com/user-attachments/assets/7339dbb6-e00f-4667-9e8e-57304df10eaa

