### PR TITLE
Switch cursor styles apply to label for accessibility affordance

### DIFF
--- a/packages/react-components/src/components/Switch/Switch.css
+++ b/packages/react-components/src/components/Switch/Switch.css
@@ -55,12 +55,11 @@
 }
 
 /* Hover */
-.bcds-react-aria-Switch[data-hovered] > .indicator {
+.bcds-react-aria-Switch[data-hovered] {
   cursor: pointer;
 }
 
 .bcds-react-aria-Switch[data-hovered][data-selected] > .indicator {
-  cursor: pointer;
   background-color: var(--surface-color-primary-hover);
 }
 
@@ -84,11 +83,11 @@
 /* Disabled */
 .bcds-react-aria-Switch[data-disabled] {
   color: var(--typography-color-disabled);
+  cursor: not-allowed;
 }
 
 .bcds-react-aria-Switch[data-disabled] > .indicator {
   background-color: var(--surface-color-primary-disabled);
-  cursor: not-allowed;
 }
 
 .bcds-react-aria-Switch[data-disabled] > .indicator::before {
@@ -98,6 +97,6 @@
 }
 
 /* Read only */
-.bcds-react-aria-Switch[data-readonly] > .indicator {
+.bcds-react-aria-Switch[data-readonly] {
   cursor: not-allowed;
 }


### PR DESCRIPTION
This moves the `cursor` CSS rules in the Switch component from child indicator/container elements to the parent element. This has the effect of displaying the interactive `pointer` cursor when a user hovers on the label of the Switch, which is clickable.

Currently:
https://github.com/user-attachments/assets/f500c93d-c4a9-427a-ac51-5e8ac34cf9e8

After this PR:
https://github.com/user-attachments/assets/9bee5b4b-3e03-482d-8821-b4a475a068a0

