### PR TITLE
React components v0.3.0

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.3.0
+
+This is a milestone release that contains the following new components:
+
+- CheckboxGroup/Checkbox
+- RadioGroup/Radio
+
+This release uses:
+
+- `react-aria-components` v1.3.3
+- `@bcgov/design-tokens`v3.1.1
+
+Component changes since v0.2.0:
+
+- Switch component gets `prefers-reduced-motion` handling to turn off animation for users that prefer reduced motion.
+- Switch component `cursor` styling applies to `children` text in addition to visual switch component.
+
 ## 0.2.3
 
 ### Changed

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgov/design-system-react-components",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@bcgov/design-tokens": "3.1.1",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "rollup": "rm -rf dist && rollup -c --bundleConfigAsCjs",


### PR DESCRIPTION
This PR updates `@bcgov/design-system-react-components` to v0.3.0. The version of the code represented by this PR is published on npm on the `next` tag as [v0.3.0-rc1](https://www.npmjs.com/package/@bcgov/design-system-react-components/v/0.3.0-rc1). There are no changes in this release compared to v0.2.3.

Once this PR is merged, I will publish v0.3.0 on npm on the default `latest` tag.

# Changelog

## 0.3.0

This is a milestone release that contains the following new components:

- CheckboxGroup/Checkbox
- RadioGroup/Radio

This release uses:

- `react-aria-components` v1.3.3
- `@bcgov/design-tokens`v3.1.1

Component changes since v0.2.0:

- Switch component gets `prefers-reduced-motion` handling to turn off animation for users that prefer reduced motion.
- Switch component `cursor` styling applies to `children` text in addition to visual switch component.