### PR TITLE
React components v0.3.1

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.1
+
+### Added
+
+- Added AlertDialog, Dialog, and Modal components.
+
 ## 0.3.0
 
 This is a milestone release that contains the following new components:

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -70,14 +70,17 @@ export default function App() {
 
 | Component               | React Aria Components docs link                                |
 | ----------------------- | -------------------------------------------------------------- |
+| AlertDialog             | N/A                                                            |
 | Button                  | https://react-spectrum.adobe.com/react-aria/Button.html        |
 | ButtonGroup             | N/A                                                            |
 | Checkbox                | https://react-spectrum.adobe.com/react-aria/Checkbox.html      |
 | CheckboxGroup           | https://react-spectrum.adobe.com/react-aria/CheckboxGroup.html |
+| Dialog                  | https://react-spectrum.adobe.com/react-aria/Dialog.html        |
 | Footer                  | N/A                                                            |
 | Form                    | https://react-spectrum.adobe.com/react-aria/Form.html          |
 | Header                  | N/A                                                            |
 | InlineAlert             | N/A                                                            |
+| Modal                   | https://react-spectrum.adobe.com/react-aria/Modal.html         |
 | RadioGroup, Radio       | https://react-spectrum.adobe.com/react-aria/RadioGroup.html    |
 | Select                  | https://react-spectrum.adobe.com/react-aria/Select.html        |
 | Switch                  | https://react-spectrum.adobe.com/react-aria/Switch.html        |

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgov/design-system-react-components",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@bcgov/design-tokens": "3.1.1",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "rollup": "rm -rf dist && rollup -c --bundleConfigAsCjs",


### PR DESCRIPTION
This PR moves the `@bcgov/design-system-react-components` to v0.3.1. This code is currently published on the `next` tag on npm as [v0.3.1-rc1](https://www.npmjs.com/package/@bcgov/design-system-react-components/v/0.3.1-rc1).

Once this is merged, I will publish v0.3.1 on the default `latest` tag.

# Changelog

## 0.3.1

### Added

- Added AlertDialog, Dialog, and Modal components.