### PR TITLE
React components v0.4.0

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.4.0
+
+This is a milestone release that contains the following new components:
+
+- AlertDialog
+- Dialog
+- Modal
+
+This release uses:
+
+- `react-aria-components` v1.3.3
+- `@bcgov/design-tokens`v3.1.1
+
+No component changes since v0.3.0.
+
 ## 0.3.1
 
 ### Added

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgov/design-system-react-components",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@bcgov/design-tokens": "3.1.1",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "rollup": "rm -rf dist && rollup -c --bundleConfigAsCjs",


### PR DESCRIPTION
This bumps `@bcgov/design-system-react-components` to the milestone version v0.4.0. This code is currently published on npm on the `next` tag as [v0.4.0-rc1](https://www.npmjs.com/package/@bcgov/design-system-react-components/v/0.4.0-rc1).

Once this is merged I will publish v0.4.0 on the default `latest` tag.

# Changelog

## 0.4.0

This is a milestone release that contains the following new components:

- AlertDialog
- Dialog
- Modal

This release uses:

- `react-aria-components` v1.3.3
- `@bcgov/design-tokens`v3.1.1

No component changes since v0.3.0.