### PR TITLE
Callout style tweaks

### DIFF
--- a/packages/react-components/src/components/Callout/Callout.css
+++ b/packages/react-components/src/components/Callout/Callout.css
@@ -3,6 +3,9 @@
   width: 100%;
   box-sizing: border-box;
   padding: var(--layout-padding-medium) var(--layout-padding-large);
+  border-radius: var(--layout-border-radius-medium)
+    var(--layout-border-radius-none) var(--layout-border-radius-none)
+    var(--layout-border-radius-medium);
 }
 
 .bcds-Callout--Container {
@@ -26,30 +29,24 @@
 .bcds-Callout.lightGrey {
   background-color: var(--surface-color-background-light-gray);
   border-left: var(--layout-border-width-large) solid var(--theme-primary-blue);
-  border-radius: var(--layout-border-radius-medium)
-    var(--layout-border-radius-none) var(--layout-border-radius-none)
-    var(--layout-border-radius-medium);
 }
 
 /* Theme - light blue */
 .bcds-Callout.lightBlue {
   background-color: var(--theme-blue-10);
   border-left: var(--layout-border-width-large) solid var(--theme-primary-blue);
-  border-radius: var(--layout-border-radius-medium);
 }
 
 /* Theme - light gold */
 .bcds-Callout.lightGold {
   background-color: var(--theme-gold-10);
   border-left: var(--layout-border-width-large) solid var(--theme-primary-blue);
-  border-radius: var(--layout-border-radius-medium);
 }
 
 /* Theme - blue  */
 .bcds-Callout.Blue {
   background-color: var(--surface-color-background-dark-blue);
   border-left: var(--layout-border-width-large) solid var(--theme-primary-gold);
-  border-radius: var(--layout-border-radius-medium);
 }
 
 .bcds-Callout.Blue .bcds-Callout--Title {
@@ -64,7 +61,6 @@
 .bcds-Callout.Grey {
   background-color: var(--theme-gray-80);
   border-left: var(--layout-border-width-large) solid var(--theme-primary-gold);
-  border-radius: var(--layout-border-radius-medium);
 }
 
 .bcds-Callout.Grey .bcds-Callout--Title {
@@ -79,7 +75,6 @@
 .bcds-Callout.Black {
   background-color: var(--theme-gray-100);
   border-left: var(--layout-border-width-large) solid var(--theme-primary-gold);
-  border-radius: var(--layout-border-radius-medium);
 }
 
 .bcds-Callout.Black .bcds-Callout--Title {

--- a/packages/react-components/src/components/Callout/Callout.css
+++ b/packages/react-components/src/components/Callout/Callout.css
@@ -1,6 +1,7 @@
 .bcds-Callout {
   display: flex;
   width: 100%;
+  box-sizing: border-box;
   padding: var(--layout-padding-medium) var(--layout-padding-large);
 }
 
@@ -25,7 +26,9 @@
 .bcds-Callout.lightGrey {
   background-color: var(--surface-color-background-light-gray);
   border-left: var(--layout-border-width-large) solid var(--theme-primary-blue);
-  border-radius: var(--layout-border-radius-medium);
+  border-radius: var(--layout-border-radius-medium)
+    var(--layout-border-radius-none) var(--layout-border-radius-none)
+    var(--layout-border-radius-medium);
 }
 
 /* Theme - light blue */


### PR DESCRIPTION
This PR corrects a couple of minor styling issues with the new `Callout` component:

1. Adds `box-sizing: border-box` constraint so that the callout will fit itself properly within its parent container
2. Refines `border-radius` so that the rounded corners are only applied on the accent stroke on the left edge
3. Simplifies `border-radius` declarations so it's defined only once, on the top-level class