### PR TITLE
Add Link component

### DIFF
--- a/packages/react-components/src/components/Link/Link.css
+++ b/packages/react-components/src/components/Link/Link.css
@@ -1,0 +1,52 @@
+.bcds-react-aria-Link {
+  color: var(--typography-color-link);
+  text-decoration: underline;
+  text-underline-offset: var(--layout-padding-hair);
+  cursor: pointer;
+}
+
+/* Sizing */
+.bcds-react-aria-Link.small {
+  font: var(--typography-regular-small-body);
+}
+
+.bcds-react-aria-Link.medium {
+  font: var(--typography-regular-body);
+}
+
+.bcds-react-aria-Link.large {
+  font: var(--typography-regular-large-body);
+}
+
+/* Placeholder large button style */
+.bcds-react-aria-Button.large {
+  min-height: 40px;
+}
+
+/* Hover */
+.bcds-react-aria-Link[data-hovered] {
+  color: var(--surface-color-border-active);
+}
+
+.bcds-react-aria-Link[data-hovered].danger {
+  color: var(--surface-color-primary-danger-button-hover);
+}
+
+/* Focus */
+.bcds-react-aria-Link[data-focus-visible] {
+  outline: solid var(--layout-border-width-medium)
+    var(--surface-color-border-active);
+  outline-offset: var(--layout-margin-hair);
+  border-radius: var(--layout-border-radius-small);
+}
+
+/* Disabled */
+.bcds-react-aria-Link[data-disabled] {
+  color: var(--typography-color-disabled);
+  cursor: not-allowed;
+}
+
+/* Danger */
+.bcds-react-aria-Link.danger {
+  color: var(--typography-color-danger);
+}

--- a/packages/react-components/src/components/Link/Link.css
+++ b/packages/react-components/src/components/Link/Link.css
@@ -5,6 +5,14 @@
   cursor: pointer;
 }
 
+/* Icon slots */
+.bcds-react-aria-Link--Icon {
+  display: inline-flex;
+  flex-direction: row;
+  vertical-align: text-bottom;
+  margin: var(--layout-margin-none) var(--layout-margin-xsmall);
+}
+
 /* Sizing */
 .bcds-react-aria-Link.small {
   font: var(--typography-regular-small-body);
@@ -41,7 +49,8 @@
 }
 
 /* Disabled */
-.bcds-react-aria-Link[data-disabled] {
+.bcds-react-aria-Link[data-disabled],
+.bcds-react-aria-Link[data-disabled].danger {
   color: var(--typography-color-disabled);
   cursor: not-allowed;
 }

--- a/packages/react-components/src/components/Link/Link.css
+++ b/packages/react-components/src/components/Link/Link.css
@@ -40,6 +40,11 @@
   color: var(--surface-color-primary-danger-button-hover);
 }
 
+/* Selected */
+.bcds-react-aria-Link[data-current] {
+  color: var(--surface-color-border-active);
+}
+
 /* Focus */
 .bcds-react-aria-Link[data-focus-visible] {
   outline: solid var(--layout-border-width-medium)

--- a/packages/react-components/src/components/Link/Link.tsx
+++ b/packages/react-components/src/components/Link/Link.tsx
@@ -4,23 +4,44 @@ import {
 } from "react-aria-components";
 
 import "./Link.css";
+import "../Button/Button.css";
 
 export interface LinkProps extends ReactAriaLinkProps {
   /* Text size */
   size?: "small" | "medium" | "large";
+  /* Toggles link to use Button styles */
+  isButton?: boolean;
+  /* Sets which Button style is applied */
+  buttonVariant?: "primary" | "secondary" | "tertiary";
   /* ARIA label */
   ariaLabel?: string | undefined;
+  /* Red colourway for danger/error states */
+  danger?: boolean;
+  /* Override all styling, let link inherit styles from parent */
+  isUnstyled?: boolean;
 }
 
 export default function Link({
   children,
   size = "medium",
+  danger = false,
+  isButton = false,
+  buttonVariant = "primary",
+  isUnstyled = false,
   ariaLabel,
   ...props
 }: LinkProps) {
   return (
     <ReactAriaLink
-      className={`bcds-react-aria-Link ${size}`}
+      className={
+        !isUnstyled
+          ? isButton
+            ? `bcds-react-aria-Button ${size} ${buttonVariant} ${
+                danger && "danger"
+              }`
+            : `bcds-react-aria-Link ${size} ${danger && "danger"}`
+          : undefined
+      }
       aria-label={ariaLabel}
       {...props}
     >

--- a/packages/react-components/src/components/Link/Link.tsx
+++ b/packages/react-components/src/components/Link/Link.tsx
@@ -1,0 +1,30 @@
+import {
+  Link as ReactAriaLink,
+  LinkProps as ReactAriaLinkProps,
+} from "react-aria-components";
+
+import "./Link.css";
+
+export interface LinkProps extends ReactAriaLinkProps {
+  /* Text size */
+  size?: "small" | "medium" | "large";
+  /* ARIA label */
+  ariaLabel?: string | undefined;
+}
+
+export default function Link({
+  children,
+  size = "medium",
+  ariaLabel,
+  ...props
+}: LinkProps) {
+  return (
+    <ReactAriaLink
+      className={`bcds-react-aria-Link ${size}`}
+      aria-label={ariaLabel}
+      {...props}
+    >
+      {children}
+    </ReactAriaLink>
+  );
+}

--- a/packages/react-components/src/components/Link/Link.tsx
+++ b/packages/react-components/src/components/Link/Link.tsx
@@ -7,6 +7,8 @@ import "./Link.css";
 import "../Button/Button.css";
 
 export interface LinkProps extends ReactAriaLinkProps {
+  /* Link content */
+  children?: React.ReactNode;
   /* Text size */
   size?: "small" | "medium" | "large";
   /* Toggles link to use Button styles */
@@ -50,15 +52,13 @@ export default function Link({
       aria-label={ariaLabel}
       {...props}
     >
-      <>
-        {iconLeft && (
-          <span className="bcds-react-aria-Link--Icon">{iconLeft}</span>
-        )}
-        {children}
-        {iconRight && (
-          <span className="bcds-react-aria-Link--Icon">{iconRight}</span>
-        )}
-      </>
+      {iconLeft && (
+        <span className="bcds-react-aria-Link--Icon">{iconLeft}</span>
+      )}
+      {children}
+      {iconRight && (
+        <span className="bcds-react-aria-Link--Icon">{iconRight}</span>
+      )}
     </ReactAriaLink>
   );
 }

--- a/packages/react-components/src/components/Link/Link.tsx
+++ b/packages/react-components/src/components/Link/Link.tsx
@@ -19,6 +19,9 @@ export interface LinkProps extends ReactAriaLinkProps {
   danger?: boolean;
   /* Override all styling, let link inherit styles from parent */
   isUnstyled?: boolean;
+  /* Icon slots */
+  iconLeft?: React.ReactElement;
+  iconRight?: React.ReactElement;
 }
 
 export default function Link({
@@ -28,6 +31,8 @@ export default function Link({
   isButton = false,
   buttonVariant = "primary",
   isUnstyled = false,
+  iconLeft,
+  iconRight,
   ariaLabel,
   ...props
 }: LinkProps) {
@@ -45,7 +50,15 @@ export default function Link({
       aria-label={ariaLabel}
       {...props}
     >
-      {children}
+      <>
+        {iconLeft && (
+          <span className="bcds-react-aria-Link--Icon">{iconLeft}</span>
+        )}
+        {children}
+        {iconRight && (
+          <span className="bcds-react-aria-Link--Icon">{iconRight}</span>
+        )}
+      </>
     </ReactAriaLink>
   );
 }

--- a/packages/react-components/src/components/Link/index.ts
+++ b/packages/react-components/src/components/Link/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./Link";
+export type { LinkProps } from "./Link";

--- a/packages/react-components/src/components/index.ts
+++ b/packages/react-components/src/components/index.ts
@@ -12,6 +12,7 @@ export { default as Footer, FooterLinks } from "./Footer";
 export { default as Form } from "./Form";
 export { default as Header } from "./Header";
 export { default as InlineAlert } from "./InlineAlert";
+export { default as Link } from "./Link";
 export { default as Modal } from "./Modal";
 export { default as Radio } from "./Radio";
 export { default as RadioGroup } from "./RadioGroup";

--- a/packages/react-components/src/stories/Link.mdx
+++ b/packages/react-components/src/stories/Link.mdx
@@ -1,0 +1,83 @@
+{/* Link.mdx */}
+
+import {
+  Canvas,
+  Controls,
+  Meta,
+  Primary,
+  Source,
+  Story,
+  Subtitle,
+} from "@storybook/blocks";
+
+import * as LinkStories from "./Link.stories";
+
+<Meta title="Utility/Link" />
+
+# Link
+
+<Subtitle>
+  A link provides a method for the user to navigate to another page, view or
+  resource within your app. They can be used inline within content, or to
+  populate navigation menus.
+</Subtitle>
+
+<Source
+  code={`import { Link } from "@bcgov/design-system-react-components";`}
+  language="typescript"
+/>
+
+## Usage and resources
+
+Link is a utility component for creating accessible and configurable hyperlinks within a user interface.
+
+It is based on [React Aria Link](https://react-spectrum.adobe.com/react-aria/Link.html). Consult the React Aria documentation for additional technical information.
+
+## Controls
+
+<Primary of={LinkStories} />
+<Controls of={LinkStories.LinkTemplate} />
+
+## Configuration
+
+Link text is set via the `children` slot.
+
+You can configure a link's behaviour using the `href` prop to provide a destination URL, or use the `onPress` prop to configure click/press events.
+
+If a link has an `href`, it renders as an `<a>` element. Otherwise, it will render a `<span>` with the ARIA "[link](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/link_role)" role.
+
+Consult the React Aria documentation for [more information about events and routing](https://react-spectrum.adobe.com/react-aria/Link.html#events).
+
+### Styling
+
+Link ships with styling based on the [B.C. Design System typescale](https://www2.gov.bc.ca/gov/content?id=72C2CD6E05494C84B9A072DD9C6A5342). Pass a CSS class with the `className` prop to override a link's styles with your own.
+
+### Size
+
+Use the `size` prop to choose between `small`, `medium` and `large` sizes:
+
+<Canvas of={LinkStories.SmallLink} />
+<Canvas of={LinkStories.MediumLink} />
+<Canvas of={LinkStories.LargeLink} />
+
+If no `size` prop is passed, it will default to `medium`.
+
+Links will match the correct heading style from the design system typescale if enclosed in an element like `<h2>`:
+
+<Canvas of={LinkStories.LinkInHeading} />
+
+### Link icons
+
+You can pass SVG graphics into the `children` slot to add icons to a link:
+
+<Canvas of={LinkStories.LinkWithLeftIcon} />
+<Canvas of={LinkStories.LinkWithRightIcon} />
+<Canvas of={LinkStories.IconOnlyLink} />
+
+**Note**: when using an icon-only link, you must also pass an accessible label for assistive technologies using the `ariaLabel` prop.
+
+### Disabled links
+
+Pass `isDisabled` to disable a link. A disabled link cannot be focused or interacted with:
+
+<Canvas of={LinkStories.DisabledLink} />

--- a/packages/react-components/src/stories/Link.mdx
+++ b/packages/react-components/src/stories/Link.mdx
@@ -48,9 +48,16 @@ If a link has an `href`, it renders as an `<a>` element. Otherwise, it will rend
 
 Consult the React Aria documentation for [more information about events and routing](https://react-spectrum.adobe.com/react-aria/Link.html#events).
 
-### Styling
+## Text links
 
-Link ships with styling based on the [B.C. Design System typescale](https://www2.gov.bc.ca/gov/content?id=72C2CD6E05494C84B9A072DD9C6A5342). Pass a CSS class with the `className` prop to override a link's styles with your own.
+### Overriding link styles
+
+Link ships with styling based on the [B.C. Design System typescale](https://www2.gov.bc.ca/gov/content?id=72C2CD6E05494C84B9A072DD9C6A5342). To override this styling, you can:
+
+- Pass your own CSS class with the `className` prop
+- Pass the `isUnstyled` prop to remove all CSS, allowing a link to inherit its styles from its parent elements
+
+<Canvas of={LinkStories.LinkInHeading} />
 
 ### Size
 
@@ -62,22 +69,32 @@ Use the `size` prop to choose between `small`, `medium` and `large` sizes:
 
 If no `size` prop is passed, it will default to `medium`.
 
-Links will match the correct heading style from the design system typescale if enclosed in an element like `<h2>`:
+### Destructive links
 
-<Canvas of={LinkStories.LinkInHeading} />
+Use the `danger` prop to indicate that a link is destructive:
 
-### Link icons
-
-You can pass SVG graphics into the `children` slot to add icons to a link:
-
-<Canvas of={LinkStories.LinkWithLeftIcon} />
-<Canvas of={LinkStories.LinkWithRightIcon} />
-<Canvas of={LinkStories.IconOnlyLink} />
-
-**Note**: when using an icon-only link, you must also pass an accessible label for assistive technologies using the `ariaLabel` prop.
+<Canvas of={LinkStories.DangerLink} />
 
 ### Disabled links
 
 Pass `isDisabled` to disable a link. A disabled link cannot be focused or interacted with:
 
 <Canvas of={LinkStories.DisabledLink} />
+
+## Button links
+
+Use the `isButton` prop to create a link that looks and behaves like the [Button](/docs/components-button-button--docs) component.
+
+The `buttonVariant` prop to choose between the `primary`, `secondary` and `tertiary` button styles:
+
+<Canvas of={LinkStories.PrimaryLinkButton} />
+<Canvas of={LinkStories.SecondaryLinkButton} />
+<Canvas of={LinkStories.TertiaryLinkButton} />
+
+If no `buttonVariant` prop is passed, it will default to `primary`. If `isButton` isn't set, `buttonVariant` won't do anything.
+
+You can use the `isDisabled`, `danger` and `size` props as normal:
+
+<Canvas of={LinkStories.DisabledLinkButton} />
+<Canvas of={LinkStories.DangerLinkButton} />
+<Canvas of={LinkStories.SmallLinkButton} />

--- a/packages/react-components/src/stories/Link.stories.tsx
+++ b/packages/react-components/src/stories/Link.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import * as tokens from "@bcgov/design-tokens/js";
 
-import { Link, SvgInfoIcon } from "../components";
+import { Link } from "../components";
 import { LinkProps } from "@/components/Link";
 
 const meta = {
@@ -13,15 +13,6 @@ const meta = {
       control: { type: "object" },
       description: "Populates link text",
     },
-    size: {
-      options: ["small", "medium", "large"],
-      control: { type: "radio" },
-      description: "Sets text size",
-    },
-    isDisabled: {
-      control: { type: "boolean" },
-      description: "Whether a link is enabled or disabled",
-    },
     href: {
       control: { type: "text" },
       description: "Destination URL",
@@ -29,6 +20,35 @@ const meta = {
     onPress: {
       control: { type: "object" },
       description: "Callback function run on press. Use instead of `href`",
+    },
+    size: {
+      options: ["small", "medium", "large"],
+      control: { type: "radio" },
+      description: "Sets text size",
+    },
+    isButton: {
+      control: { type: "boolean" },
+      description: "Applies button styling",
+    },
+    buttonVariant: {
+      options: ["primary", "secondary", "tertiary"],
+      control: { type: "radio" },
+      description:
+        "Selects which button style is used. Requires `isButton` to be `true`",
+    },
+    isDisabled: {
+      control: { type: "boolean" },
+      description: "Whether a link is enabled or disabled",
+    },
+    isUnstyled: {
+      control: { type: "boolean" },
+      description:
+        "Overrides all styling, allowing link to inherit styling from its parent",
+    },
+    ariaLabel: {
+      control: { type: "text" },
+      description:
+        "Sets aria-label attribute, use if not providing a visible text label",
     },
   },
 } satisfies Meta<typeof Link>;
@@ -73,6 +93,15 @@ export const LargeLink: Story = {
   },
 };
 
+export const DangerLink: Story = {
+  ...LinkTemplate,
+  args: {
+    danger: true,
+    children: ["This link is destructive"],
+    onPress: () => alert("onPress()"),
+  },
+};
+
 export const DisabledLink: Story = {
   ...LinkTemplate,
   args: {
@@ -82,38 +111,72 @@ export const DisabledLink: Story = {
   },
 };
 
-export const LinkWithLeftIcon: Story = {
-  ...LinkTemplate,
-  args: {
-    size: "small",
-    children: [<SvgInfoIcon />, "This link has an icon"],
-    onPress: () => alert("onPress()"),
-  },
-};
-
-export const LinkWithRightIcon: Story = {
-  ...LinkTemplate,
-  args: {
-    size: "small",
-    children: ["This link has an icon", <SvgInfoIcon />],
-    onPress: () => alert("onPress()"),
-  },
-};
-
-export const IconOnlyLink: Story = {
-  ...LinkTemplate,
-  args: {
-    children: [<SvgInfoIcon />],
-    ariaLabel: "Information",
-    onPress: () => alert("onPress()"),
-  },
-};
-
 export const LinkInHeading: Story = {
-  args: { children: ["This link"], onPress: () => alert("onPress()") },
+  args: {
+    children: ["This link"],
+    href: "#",
+    isUnstyled: true,
+  },
   render: ({ ...args }: LinkProps) => (
     <h2 style={{ font: tokens.typographyBoldH2 }}>
       <Link {...args} /> is part of an H2 heading
     </h2>
   ),
+};
+
+export const PrimaryLinkButton: Story = {
+  args: {
+    children: ["This is a link button"],
+    isButton: true,
+    buttonVariant: "primary",
+    onPress: () => alert("onPress()"),
+  },
+};
+
+export const SecondaryLinkButton: Story = {
+  args: {
+    children: ["This is a link button"],
+    isButton: true,
+    buttonVariant: "secondary",
+    onPress: () => alert("onPress()"),
+  },
+};
+
+export const TertiaryLinkButton: Story = {
+  args: {
+    children: ["This is a link button"],
+    isButton: true,
+    buttonVariant: "tertiary",
+    onPress: () => alert("onPress()"),
+  },
+};
+
+export const DisabledLinkButton: Story = {
+  args: {
+    children: ["This link button is disabled"],
+    isButton: true,
+    buttonVariant: "primary",
+    isDisabled: true,
+    onPress: () => alert("onPress()"),
+  },
+};
+
+export const DangerLinkButton: Story = {
+  args: {
+    children: ["This is a destructive link button"],
+    isButton: true,
+    buttonVariant: "primary",
+    danger: true,
+    onPress: () => alert("onPress()"),
+  },
+};
+
+export const SmallLinkButton: Story = {
+  args: {
+    children: ["This is a small link button"],
+    isButton: true,
+    buttonVariant: "primary",
+    size: "small",
+    onPress: () => alert("onPress()"),
+  },
 };

--- a/packages/react-components/src/stories/Link.stories.tsx
+++ b/packages/react-components/src/stories/Link.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import * as tokens from "@bcgov/design-tokens/js";
+
+import { Link, SvgInfoIcon } from "../components";
+import { LinkProps } from "@/components/Link";
+
+const meta = {
+  title: "Utility/Link",
+  component: Link,
+  parameters: { layout: "centered" },
+  argTypes: {
+    children: {
+      control: { type: "object" },
+      description: "Populates link text",
+    },
+    size: {
+      options: ["small", "medium", "large"],
+      control: { type: "radio" },
+      description: "Sets text size",
+    },
+    isDisabled: {
+      control: { type: "boolean" },
+      description: "Whether a link is enabled or disabled",
+    },
+    href: {
+      control: { type: "text" },
+      description: "Destination URL",
+    },
+    onPress: {
+      control: { type: "object" },
+      description: "Callback function run on press. Use instead of `href`",
+    },
+  },
+} satisfies Meta<typeof Link>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const LinkTemplate: Story = {
+  args: {
+    size: "medium",
+    children: ["Link text"],
+    onPress: () => alert("onPress()"),
+    isDisabled: false,
+  },
+  render: ({ ...args }: LinkProps) => <Link {...args} />,
+};
+
+export const SmallLink: Story = {
+  ...LinkTemplate,
+  args: {
+    size: "small",
+    children: ["This link uses the default small text size"],
+    onPress: () => alert("onPress()"),
+  },
+};
+
+export const MediumLink: Story = {
+  ...LinkTemplate,
+  args: {
+    size: "medium",
+    children: ["This link uses the medium text size"],
+    onPress: () => alert("onPress()"),
+  },
+};
+
+export const LargeLink: Story = {
+  ...LinkTemplate,
+  args: {
+    size: "large",
+    children: ["This link uses the large text size"],
+    onPress: () => alert("onPress()"),
+  },
+};
+
+export const DisabledLink: Story = {
+  ...LinkTemplate,
+  args: {
+    isDisabled: true,
+    size: "medium",
+    children: ["This link is disabled"],
+  },
+};
+
+export const LinkWithLeftIcon: Story = {
+  ...LinkTemplate,
+  args: {
+    size: "small",
+    children: [<SvgInfoIcon />, "This link has an icon"],
+    onPress: () => alert("onPress()"),
+  },
+};
+
+export const LinkWithRightIcon: Story = {
+  ...LinkTemplate,
+  args: {
+    size: "small",
+    children: ["This link has an icon", <SvgInfoIcon />],
+    onPress: () => alert("onPress()"),
+  },
+};
+
+export const IconOnlyLink: Story = {
+  ...LinkTemplate,
+  args: {
+    children: [<SvgInfoIcon />],
+    ariaLabel: "Information",
+    onPress: () => alert("onPress()"),
+  },
+};
+
+export const LinkInHeading: Story = {
+  args: { children: ["This link"], onPress: () => alert("onPress()") },
+  render: ({ ...args }: LinkProps) => (
+    <h2 style={{ font: tokens.typographyBoldH2 }}>
+      <Link {...args} /> is part of an H2 heading
+    </h2>
+  ),
+};


### PR DESCRIPTION
WIP/draft PR for discussion and feedback. @Supriya-Arora: this is carved out from a bigger piece of work around menus/navbars. Also cc'ing @ty2k for input — we've discussed this a little bit, would appreciate your take.

This PR adds a new Link component, based on [RAC Link](https://react-spectrum.adobe.com/react-aria/Link.html). Docs and examples are included in Storybook.

As the name suggests, Link is a utility component for creating accessible and extensible hyperlinks. In the design system context, its primary usage is in navigation (eg. populating menus within the Header and Footer components), but it can also be used inline.

## Text links
Link text is populated using the `children` slot. Link behaviour is configured using the `href` (renders a standard `<a>` element) or `onPress` (renders a `<span>` with the ARIA "link" role) props. See the RAC docs for [information about events and routing](https://react-spectrum.adobe.com/react-aria/Link.html#events).

A Link renders with the `.bcds-react-aria-Link` class. The `size` and `danger` props are used to append additional classes (toggling between S/M/L text sizes and a red colourway for destructive or dangerous links.)

The user can override link styling entirely by either:

- Passing their own CSS class using `className`
- Using the `isUnstyled` prop, which removes all styling and allows a link to inherit its styles from its parents

A Link can be disabled using `isDisabled`.

## Link buttons
Using the `isButton` prop, Link can also be styled to look and behave like the Button component. When `isButton` is set, Link will render with the `.bcds-react-aria-Button` class instead of `.bcds-react-aria-Link`. The `buttonVariant` prop replicates the functionality of `variant` on the Button component. Link imports `Button.css` directly to avoid duplicating styles.

The reasoning for this functionality is to better align with how [RAC Button](https://react-spectrum.adobe.com/react-aria/Button.html#link-buttons) works: 

> The Button component always represents a button semantically. To create a link that visually looks like a button, use the [Link](https://react-spectrum.adobe.com/react-aria/Link.html) component instead.

Unlike our Button component, Link supports the `href` prop natively.