### PR TITLE
React Component v0.5.0

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.5.0
+
+This is a milestone release that contains the following new components:
+
+- Accordion and accordion group
+- Alert Banner
+- Callout
+
+This release uses:
+
+- `react-aria-components` v1.5.0
+- `@bcgov/design-tokens`v3.2.0
+
+Component changes since v0.4.0:
+
+- Add an alternative `chip` style to Tag and Tag group component.
+
 ## 0.4.0
 
 This is a milestone release that contains the following new components:

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -68,25 +68,29 @@ export default function App() {
 
 ## Component list
 
-| Component               | React Aria Components docs link                                |
-| ----------------------- | -------------------------------------------------------------- |
-| AlertDialog             | N/A                                                            |
-| Button                  | https://react-spectrum.adobe.com/react-aria/Button.html        |
-| ButtonGroup             | N/A                                                            |
-| Checkbox                | https://react-spectrum.adobe.com/react-aria/Checkbox.html      |
-| CheckboxGroup           | https://react-spectrum.adobe.com/react-aria/CheckboxGroup.html |
-| Dialog                  | https://react-spectrum.adobe.com/react-aria/Dialog.html        |
-| Footer                  | N/A                                                            |
-| Form                    | https://react-spectrum.adobe.com/react-aria/Form.html          |
-| Header                  | N/A                                                            |
-| InlineAlert             | N/A                                                            |
-| Modal                   | https://react-spectrum.adobe.com/react-aria/Modal.html         |
-| RadioGroup, Radio       | https://react-spectrum.adobe.com/react-aria/RadioGroup.html    |
-| Select                  | https://react-spectrum.adobe.com/react-aria/Select.html        |
-| Switch                  | https://react-spectrum.adobe.com/react-aria/Switch.html        |
-| TagGroup, TagList, Tag  | https://react-spectrum.adobe.com/react-aria/TagGroup.html      |
-| TextArea, TextField     | https://react-spectrum.adobe.com/react-aria/TextField.html     |
-| Tooltip, TooltipTrigger | https://react-spectrum.adobe.com/react-aria/Tooltip.html       |
+| Component               | React Aria Components docs link                                  |
+| ----------------------- | ---------------------------------------------------------------- |
+| AlertBanner             | N/A                                                              |
+| AlertDialog             | N/A                                                              |
+| Accordion               | https://react-spectrum.adobe.com/react-aria/Disclosure.html      |
+| AccordionGroup          | https://react-spectrum.adobe.com/react-aria/DisclosureGroup.html |
+| Button                  | https://react-spectrum.adobe.com/react-aria/Button.html          |
+| ButtonGroup             | N/A                                                              |
+| Callout                 | N/A                                                              |
+| Checkbox                | https://react-spectrum.adobe.com/react-aria/Checkbox.html        |
+| CheckboxGroup           | https://react-spectrum.adobe.com/react-aria/CheckboxGroup.html   |
+| Dialog                  | https://react-spectrum.adobe.com/react-aria/Dialog.html          |
+| Footer                  | N/A                                                              |
+| Form                    | https://react-spectrum.adobe.com/react-aria/Form.html            |
+| Header                  | N/A                                                              |
+| InlineAlert             | N/A                                                              |
+| Modal                   | https://react-spectrum.adobe.com/react-aria/Modal.html           |
+| RadioGroup, Radio       | https://react-spectrum.adobe.com/react-aria/RadioGroup.html      |
+| Select                  | https://react-spectrum.adobe.com/react-aria/Select.html          |
+| Switch                  | https://react-spectrum.adobe.com/react-aria/Switch.html          |
+| TagGroup, TagList, Tag  | https://react-spectrum.adobe.com/react-aria/TagGroup.html        |
+| TextArea, TextField     | https://react-spectrum.adobe.com/react-aria/TextField.html       |
+| Tooltip, TooltipTrigger | https://react-spectrum.adobe.com/react-aria/Tooltip.html         |
 
 ## Supported React versions
 

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgov/design-system-react-components",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@bcgov/design-tokens": "3.1.1",
+        "@bcgov/design-tokens": "3.2.0",
         "react-aria-components": "1.5.0"
       },
       "devDependencies": {
@@ -666,10 +666,9 @@
       "peer": true
     },
     "node_modules/@bcgov/design-tokens": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@bcgov/design-tokens/-/design-tokens-3.1.1.tgz",
-      "integrity": "sha512-b+7O0SQmqVez6lBL9TBTdWSMLgMRscuuBUaKT0ihR/LloKpnkGFgepoM8P14jNyK4ROn8SdoJv/fhR2FEW7Hug==",
-      "license": "Apache-2.0"
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@bcgov/design-tokens/-/design-tokens-3.2.0.tgz",
+      "integrity": "sha512-2D3mPFKTpNLeIp8ER9y8oDKxXE8+rBfcvuF4yFd7uUvDm0izZNFhambUi6sN3OdkmuZoGQO7AjlMtOQzsHtxzA=="
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "rollup": "rm -rf dist && rollup -c --bundleConfigAsCjs",
@@ -23,7 +23,7 @@
   ],
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@bcgov/design-tokens": "3.1.1",
+    "@bcgov/design-tokens": "3.2.0",
     "react-aria-components": "1.5.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This is a milestone release that contains the following new components:

- Accordion and accordion group
- Alert Banner
- Callout

This release uses:

- `react-aria-components` v1.5.0
- `@bcgov/design-tokens`v3.2.0

Component changes since v0.4.0:

- Add an alternative `chip` style to Tag and Tag group component.