### PR TITLE
SCSS format support

### DIFF
--- a/packages/design-tokens/build-output.js
+++ b/packages/design-tokens/build-output.js
@@ -226,6 +226,30 @@ const sd = new StyleDictionary({
         },
       ],
     },
+    scss: {
+      transformGroup: "tokens-studio",
+      transforms: [
+        "bcds/typography/italic",
+        "bcds/color/uppercase",
+        "bcds/css/size/zero",
+        "name/kebab",
+      ],
+      buildPath: "build/scss/",
+      files: [
+        {
+          destination: "variables.scss",
+          format: "scss/map-deep",
+          filter: (t) => (
+            /* strip metadata */
+            !(['$themes', '$metadata'].includes(t))
+          ),
+          options: {
+            "mapName": "bcds",
+            "themeable": false
+          }
+        },
+      ],
+    },
   },
 });
 

--- a/packages/design-tokens/build-output.test.js
+++ b/packages/design-tokens/build-output.test.js
@@ -40,6 +40,7 @@ test("output files should exist after running build-output.js", async () => {
     "build/cjs/index.d.ts",
     "build/cjs-prefixed/index.js",
     "build/cjs-prefixed/index.d.ts",
+    "build/scss/variables.scss",
   ];
 
   for (const file of outputFiles) {


### PR DESCRIPTION
Add the StyleDictionary built in support for SCSS variables generation to the build script. Some frameworks (Bootstrap, and Quarto, at least) benefit from the flexibility of SCSS variables versus CSS.