### PR TITLE
Add ToggleButton and ToggleButtonGroup components

### DIFF
--- a/packages/react-components/src/App.tsx
+++ b/packages/react-components/src/App.tsx
@@ -22,6 +22,7 @@ import {
   TextFieldPage,
   SwitchPage,
   TooltipPage,
+  ToggleButtonGroupPage,
 } from "@/pages";
 
 // This icon is available as a plain SVG at src/assets/icon-menu.svg
@@ -169,6 +170,7 @@ function App() {
         <TooltipPage />
         <TextAreaPage />
         <TextFieldPage />
+        <ToggleButtonGroupPage />
       </main>
       <Footer />
       <Footer

--- a/packages/react-components/src/components/ToggleButton/ToggleButton.css
+++ b/packages/react-components/src/components/ToggleButton/ToggleButton.css
@@ -8,6 +8,7 @@
   background-color: var(--surface-color-secondary-button-disabled);
   padding: var(--layout-padding-hair) var(--layout-padding-small);
   border: none;
+  border-radius: var(--layout-border-radius-medium);
   cursor: pointer;
   box-sizing: content-box;
 }
@@ -18,7 +19,7 @@
   color: var(--typography-color-primary);
   border: var(--layout-border-width-small) solid
     var(--surface-color-border-default);
-  border-radius: var(--layout-border-radius-small);
+  border-radius: var(--layout-border-radius-medium);
   box-shadow: var(--surface-shadow-small);
 }
 
@@ -28,12 +29,12 @@
   color: var(--typography-color-primary);
   border: var(--layout-border-width-small) solid
     var(--surface-color-border-default);
-  border-radius: var(--layout-border-radius-small);
+  border-radius: var(--layout-border-radius-medium);
 }
 
 /* Focused */
 .bcds-react-aria-ToggleButton[data-focus-visible] {
-  border-radius: var(--layout-border-radius-small);
+  border-radius: var(--layout-border-radius-medium);
   outline: solid var(--layout-border-width-medium)
     var(--surface-color-border-active);
   outline-offset: var(--layout-margin-hair);

--- a/packages/react-components/src/components/ToggleButton/ToggleButton.css
+++ b/packages/react-components/src/components/ToggleButton/ToggleButton.css
@@ -1,14 +1,47 @@
 .bcds-react-aria-ToggleButton {
   font: var(--typography-regular-body);
-  color: var(--typography-color-disabled);
+  color: var(--typography-color-secondary);
+  background-color: var(--surface-color-secondary-button-disabled);
+  padding: var(--layout-padding-xsmall) var(--layout-padding-small);
   border: none;
   cursor: pointer;
+  box-sizing: border-box;
 }
 
+/* Active */
 .bcds-react-aria-ToggleButton[data-selected] {
   background-color: var(--surface-color-secondary-button-default);
   color: var(--typography-color-primary);
   border: var(--layout-border-width-small) solid
     var(--surface-color-border-default);
   border-radius: var(--layout-border-radius-small);
+  box-shadow: var(--surface-shadow-small);
+}
+
+/* Hover */
+.bcds-react-aria-ToggleButton[data-hovered] {
+  background-color: var(--surface-color-secondary-button-default);
+  color: var(--typography-color-primary);
+  border: var(--layout-border-width-small) solid
+    var(--surface-color-border-default);
+  border-radius: var(--layout-border-radius-small);
+}
+
+/* Focused */
+.bcds-react-aria-ToggleButton[data-focus-visible] {
+  border-radius: var(--layout-border-radius-small);
+  outline: solid var(--layout-border-width-medium)
+    var(--surface-color-border-active);
+  outline-offset: var(--layout-margin-hair);
+}
+
+/* Disabled */
+.bcds-react-aria-ToggleButton[data-disabled] {
+  color: var(--typography-color-disabled);
+  cursor: not-allowed;
+}
+
+/* Danger */
+.bcds-react-aria-ToggleButton.danger {
+  color: var(--typography-color-danger);
 }

--- a/packages/react-components/src/components/ToggleButton/ToggleButton.css
+++ b/packages/react-components/src/components/ToggleButton/ToggleButton.css
@@ -1,16 +1,29 @@
 .bcds-react-aria-ToggleButton {
   display: flex;
   flex-direction: row;
+  box-sizing: content-box;
   gap: var(--layout-margin-xsmall);
   align-items: center;
   font: var(--typography-regular-body);
   color: var(--typography-color-secondary);
   background-color: var(--surface-color-secondary-button-disabled);
-  padding: var(--layout-padding-hair) var(--layout-padding-small);
   border: none;
   border-radius: var(--layout-border-radius-medium);
   cursor: pointer;
-  box-sizing: content-box;
+}
+
+/* Size */
+.bcds-react-aria-ToggleButton.small {
+  padding: var(--layout-padding-none) var(--layout-padding-small);
+}
+
+.bcds-react-aria-ToggleButton.medium {
+  padding: var(--layout-padding-hair) var(--layout-padding-small);
+}
+
+/* Pressed */
+.bcds-react-aria-ToggleButton[data-pressed] {
+  background-color: var(--theme-blue-10);
 }
 
 /* Active */
@@ -19,7 +32,6 @@
   color: var(--typography-color-primary);
   border: var(--layout-border-width-small) solid
     var(--surface-color-border-default);
-  border-radius: var(--layout-border-radius-medium);
   box-shadow: var(--surface-shadow-small);
 }
 

--- a/packages/react-components/src/components/ToggleButton/ToggleButton.css
+++ b/packages/react-components/src/components/ToggleButton/ToggleButton.css
@@ -1,8 +1,12 @@
 .bcds-react-aria-ToggleButton {
+  display: flex;
+  flex-direction: row;
+  gap: var(--layout-margin-xsmall);
+  align-items: center;
   font: var(--typography-regular-body);
   color: var(--typography-color-secondary);
   background-color: var(--surface-color-secondary-button-disabled);
-  padding: var(--layout-padding-xsmall) var(--layout-padding-small);
+  padding: var(--layout-padding-hair) var(--layout-padding-xsmall);
   border: none;
   cursor: pointer;
   box-sizing: content-box;

--- a/packages/react-components/src/components/ToggleButton/ToggleButton.css
+++ b/packages/react-components/src/components/ToggleButton/ToggleButton.css
@@ -22,7 +22,7 @@
 }
 
 /* Pressed */
-.bcds-react-aria-ToggleButton[data-pressed] {
+.bcds-react-aria-ToggleButton[data-hovered][data-pressed] {
   background-color: var(--theme-blue-10);
 }
 

--- a/packages/react-components/src/components/ToggleButton/ToggleButton.css
+++ b/packages/react-components/src/components/ToggleButton/ToggleButton.css
@@ -6,7 +6,7 @@
   font: var(--typography-regular-body);
   color: var(--typography-color-secondary);
   background-color: var(--surface-color-secondary-button-disabled);
-  padding: var(--layout-padding-hair) var(--layout-padding-xsmall);
+  padding: var(--layout-padding-hair) var(--layout-padding-small);
   border: none;
   cursor: pointer;
   box-sizing: content-box;

--- a/packages/react-components/src/components/ToggleButton/ToggleButton.css
+++ b/packages/react-components/src/components/ToggleButton/ToggleButton.css
@@ -5,7 +5,7 @@
   padding: var(--layout-padding-xsmall) var(--layout-padding-small);
   border: none;
   cursor: pointer;
-  box-sizing: border-box;
+  box-sizing: content-box;
 }
 
 /* Active */

--- a/packages/react-components/src/components/ToggleButton/ToggleButton.css
+++ b/packages/react-components/src/components/ToggleButton/ToggleButton.css
@@ -1,2 +1,14 @@
 .bcds-react-aria-ToggleButton {
+  font: var(--typography-regular-body);
+  color: var(--typography-color-disabled);
+  border: none;
+  cursor: pointer;
+}
+
+.bcds-react-aria-ToggleButton[data-selected] {
+  background-color: var(--surface-color-secondary-button-default);
+  color: var(--typography-color-primary);
+  border: var(--layout-border-width-small) solid
+    var(--surface-color-border-default);
+  border-radius: var(--layout-border-radius-small);
 }

--- a/packages/react-components/src/components/ToggleButton/ToggleButton.css
+++ b/packages/react-components/src/components/ToggleButton/ToggleButton.css
@@ -1,0 +1,2 @@
+.bcds-react-aria-ToggleButton {
+}

--- a/packages/react-components/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/react-components/src/components/ToggleButton/ToggleButton.tsx
@@ -6,18 +6,22 @@ import {
 import "./ToggleButton.css";
 
 export interface ToggleButtonProps extends ReactAriaToggleButtonProps {
+  size?: "small" | "medium";
   isIconButton?: boolean;
   danger?: boolean;
 }
 
 export default function ToggleButton({
-  children,
+  size = "medium",
   danger = false,
+  children,
   ...props
 }: ToggleButtonProps) {
   return (
     <ReactAriaToggleButton
-      className={`bcds-react-aria-ToggleButton ${danger ? "danger" : null}`}
+      className={`bcds-react-aria-ToggleButton ${size} ${
+        danger ? "danger" : null
+      }`}
       {...props}
     >
       {children}

--- a/packages/react-components/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/react-components/src/components/ToggleButton/ToggleButton.tsx
@@ -1,0 +1,22 @@
+import {
+  ToggleButton as ReactAriaToggleButton,
+  ToggleButtonProps as ReactAriaToggleButtonProps,
+} from "react-aria-components";
+
+import "./ToggleButton.css";
+
+export interface ToggleButtonProps extends ReactAriaToggleButtonProps {}
+
+export default function ToggleButton({
+  children,
+  ...props
+}: ToggleButtonProps) {
+  return (
+    <ReactAriaToggleButton
+      className={`bcds-react-aria-ToggleButton`}
+      {...props}
+    >
+      {children}
+    </ReactAriaToggleButton>
+  );
+}

--- a/packages/react-components/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/react-components/src/components/ToggleButton/ToggleButton.tsx
@@ -5,15 +5,19 @@ import {
 
 import "./ToggleButton.css";
 
-export interface ToggleButtonProps extends ReactAriaToggleButtonProps {}
+export interface ToggleButtonProps extends ReactAriaToggleButtonProps {
+  isIconButton?: boolean;
+  danger?: boolean;
+}
 
 export default function ToggleButton({
   children,
+  danger = false,
   ...props
 }: ToggleButtonProps) {
   return (
     <ReactAriaToggleButton
-      className={`bcds-react-aria-ToggleButton`}
+      className={`bcds-react-aria-ToggleButton ${danger ? "danger" : null}`}
       {...props}
     >
       {children}

--- a/packages/react-components/src/components/ToggleButton/index.ts
+++ b/packages/react-components/src/components/ToggleButton/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./ToggleButton";
+export type { ToggleButtonProps } from "./ToggleButton";

--- a/packages/react-components/src/components/ToggleButtonGroup/ToggleButtonGroup.css
+++ b/packages/react-components/src/components/ToggleButtonGroup/ToggleButtonGroup.css
@@ -1,2 +1,7 @@
 .bcds-react-aria-ToggleButtonGroup {
+  display: inline-flex;
+  gap: var(--layout-margin-small);
+  background-color: var(--surface-color-secondary-button-disabled);
+  padding: var(--layout-padding-xsmall);
+  border-radius: var(--layout-border-radius-small);
 }

--- a/packages/react-components/src/components/ToggleButtonGroup/ToggleButtonGroup.css
+++ b/packages/react-components/src/components/ToggleButtonGroup/ToggleButtonGroup.css
@@ -3,7 +3,7 @@
   gap: var(--layout-margin-xsmall);
   align-items: center;
   background-color: var(--surface-color-secondary-button-disabled);
-  padding: var(--layout-padding-small);
+  padding: var(--layout-padding-xsmall);
   border-radius: var(--layout-border-radius-small);
   box-sizing: content-box;
 }

--- a/packages/react-components/src/components/ToggleButtonGroup/ToggleButtonGroup.css
+++ b/packages/react-components/src/components/ToggleButtonGroup/ToggleButtonGroup.css
@@ -1,7 +1,25 @@
 .bcds-react-aria-ToggleButtonGroup {
   display: inline-flex;
   gap: var(--layout-margin-small);
+  align-items: center;
   background-color: var(--surface-color-secondary-button-disabled);
   padding: var(--layout-padding-xsmall);
   border-radius: var(--layout-border-radius-small);
+}
+
+/* Orientation */
+.bcds-react-aria-ToggleButtonGroup[data-orientation="horizontal"] {
+  flex-direction: row;
+}
+
+.bcds-react-aria-ToggleButtonGroup[data-orientation="vertical"] {
+  flex-direction: column;
+}
+
+/* Label */
+.bcds-react-aria-ToggleButtonGroup--Label {
+  display: flex;
+  padding: var(--layout-padding-small) var(--layout-padding-none);
+  font: var(--typography-regular-small-body);
+  color: var(--typography-color-secondary);
 }

--- a/packages/react-components/src/components/ToggleButtonGroup/ToggleButtonGroup.css
+++ b/packages/react-components/src/components/ToggleButtonGroup/ToggleButtonGroup.css
@@ -4,7 +4,7 @@
   align-items: center;
   background-color: var(--surface-color-secondary-button-disabled);
   padding: var(--layout-padding-xsmall);
-  border-radius: var(--layout-border-radius-small);
+  border-radius: var(--layout-border-radius-medium);
   box-sizing: content-box;
 }
 

--- a/packages/react-components/src/components/ToggleButtonGroup/ToggleButtonGroup.css
+++ b/packages/react-components/src/components/ToggleButtonGroup/ToggleButtonGroup.css
@@ -1,0 +1,2 @@
+.bcds-react-aria-ToggleButtonGroup {
+}

--- a/packages/react-components/src/components/ToggleButtonGroup/ToggleButtonGroup.css
+++ b/packages/react-components/src/components/ToggleButtonGroup/ToggleButtonGroup.css
@@ -1,15 +1,17 @@
 .bcds-react-aria-ToggleButtonGroup {
   display: inline-flex;
-  gap: var(--layout-margin-small);
+  gap: var(--layout-margin-xsmall);
   align-items: center;
   background-color: var(--surface-color-secondary-button-disabled);
-  padding: var(--layout-padding-xsmall);
+  padding: var(--layout-padding-small);
   border-radius: var(--layout-border-radius-small);
+  box-sizing: content-box;
 }
 
 /* Orientation */
 .bcds-react-aria-ToggleButtonGroup[data-orientation="horizontal"] {
   flex-direction: row;
+  height: var(--layout-margin-xlarge);
 }
 
 .bcds-react-aria-ToggleButtonGroup[data-orientation="vertical"] {

--- a/packages/react-components/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/react-components/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -1,0 +1,20 @@
+import {
+  ToggleButtonGroup as ReactAriaToggleButtonGroup,
+  ToggleButtonGroupProps,
+} from "react-aria-components";
+
+import "./ToggleButtonGroup.css";
+
+export default function ToggleButtonGroup({
+  children,
+  ...props
+}: ToggleButtonGroupProps) {
+  return (
+    <ReactAriaToggleButtonGroup
+      className="bcds-react-aria-ToggleButtonGroup"
+      {...props}
+    >
+      {children}
+    </ReactAriaToggleButtonGroup>
+  );
+}

--- a/packages/react-components/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/react-components/src/components/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -1,20 +1,34 @@
 import {
   ToggleButtonGroup as ReactAriaToggleButtonGroup,
-  ToggleButtonGroupProps,
+  ToggleButtonGroupProps as ReactAriaToggleButtonGroupProps,
+  Text,
 } from "react-aria-components";
 
 import "./ToggleButtonGroup.css";
 
+export interface ToggleButtonGroupProps
+  extends ReactAriaToggleButtonGroupProps {
+  label?: string;
+}
+
 export default function ToggleButtonGroup({
+  label,
   children,
   ...props
 }: ToggleButtonGroupProps) {
   return (
-    <ReactAriaToggleButtonGroup
-      className="bcds-react-aria-ToggleButtonGroup"
-      {...props}
-    >
-      {children}
-    </ReactAriaToggleButtonGroup>
+    <>
+      {label && (
+        <Text className="bcds-react-aria-ToggleButtonGroup--Label">
+          {label}
+        </Text>
+      )}
+      <ReactAriaToggleButtonGroup
+        className="bcds-react-aria-ToggleButtonGroup"
+        {...props}
+      >
+        {children}
+      </ReactAriaToggleButtonGroup>
+    </>
   );
 }

--- a/packages/react-components/src/components/ToggleButtonGroup/index.ts
+++ b/packages/react-components/src/components/ToggleButtonGroup/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./ToggleButtonGroup";
+export type { ToggleButtonGroupProps } from "react-aria-components";

--- a/packages/react-components/src/components/index.ts
+++ b/packages/react-components/src/components/index.ts
@@ -36,5 +36,7 @@ export { default as TagGroup } from "./TagGroup";
 export { default as TagList } from "./TagList";
 export { default as TextArea } from "./TextArea";
 export { default as TextField } from "./TextField";
+export { default as ToggleButton } from "./ToggleButton";
+export { default as ToggleButtonGroup } from "./ToggleButtonGroup";
 export { default as Switch } from "./Switch";
 export { default as Tooltip, TooltipTrigger } from "./Tooltip";

--- a/packages/react-components/src/pages/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/react-components/src/pages/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -1,11 +1,20 @@
-import { ToggleButton, ToggleButtonGroup } from "@/components";
+import {
+  ToggleButton,
+  ToggleButtonGroup,
+  SvgCheckCircleIcon,
+  SvgCloseIcon,
+  SvgExclamationCircleIcon,
+} from "@/components";
 
 export default function ToggleButtonGroupPage() {
   return (
     <>
       <h2>Toggle Button Group</h2>
       <ToggleButtonGroup label="This is a text label">
-        <ToggleButton id="1">Button 1</ToggleButton>
+        <ToggleButton id="1">
+          <SvgCheckCircleIcon />
+          Button 1
+        </ToggleButton>
         <ToggleButton id="2">Button 2</ToggleButton>
         <ToggleButton id="3">Button 3</ToggleButton>
       </ToggleButtonGroup>
@@ -25,6 +34,18 @@ export default function ToggleButtonGroupPage() {
           Button 2
         </ToggleButton>
         <ToggleButton id="3">Button 3</ToggleButton>
+      </ToggleButtonGroup>
+      <h3>Icon buttons</h3>
+      <ToggleButtonGroup selectionMode="multiple" label="This is a text label">
+        <ToggleButton id="1">
+          <SvgCheckCircleIcon />
+        </ToggleButton>
+        <ToggleButton id="2">
+          <SvgExclamationCircleIcon />
+        </ToggleButton>
+        <ToggleButton id="3">
+          <SvgCloseIcon />
+        </ToggleButton>
       </ToggleButtonGroup>
     </>
   );

--- a/packages/react-components/src/pages/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/react-components/src/pages/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -4,7 +4,7 @@ export default function ToggleButtonGroupPage() {
   return (
     <>
       <h2>Toggle Button Group</h2>
-      <ToggleButtonGroup>
+      <ToggleButtonGroup label="This is a text label">
         <ToggleButton id="1">Button 1</ToggleButton>
         <ToggleButton id="2">Button 2</ToggleButton>
         <ToggleButton id="3">Button 3</ToggleButton>
@@ -13,6 +13,17 @@ export default function ToggleButtonGroupPage() {
       <ToggleButtonGroup selectionMode="multiple">
         <ToggleButton id="1">Button 1</ToggleButton>
         <ToggleButton id="2">Button 2</ToggleButton>
+        <ToggleButton id="3">Button 3</ToggleButton>
+        <ToggleButton id="4" isDisabled>
+          Button 4 (disabled)
+        </ToggleButton>
+      </ToggleButtonGroup>
+      <h3>Vertical orientation</h3>
+      <ToggleButtonGroup orientation="vertical" label="This is a text label">
+        <ToggleButton id="1">Button 1</ToggleButton>
+        <ToggleButton id="2" danger>
+          Button 2
+        </ToggleButton>
         <ToggleButton id="3">Button 3</ToggleButton>
       </ToggleButtonGroup>
     </>

--- a/packages/react-components/src/pages/ToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/react-components/src/pages/ToggleButtonGroup/ToggleButtonGroup.tsx
@@ -1,0 +1,20 @@
+import { ToggleButton, ToggleButtonGroup } from "@/components";
+
+export default function ToggleButtonGroupPage() {
+  return (
+    <>
+      <h2>Toggle Button Group</h2>
+      <ToggleButtonGroup>
+        <ToggleButton id="1">Button 1</ToggleButton>
+        <ToggleButton id="2">Button 2</ToggleButton>
+        <ToggleButton id="3">Button 3</ToggleButton>
+      </ToggleButtonGroup>
+      <h3>Multiple selection</h3>
+      <ToggleButtonGroup selectionMode="multiple">
+        <ToggleButton id="1">Button 1</ToggleButton>
+        <ToggleButton id="2">Button 2</ToggleButton>
+        <ToggleButton id="3">Button 3</ToggleButton>
+      </ToggleButtonGroup>
+    </>
+  );
+}

--- a/packages/react-components/src/pages/ToggleButtonGroup/index.ts
+++ b/packages/react-components/src/pages/ToggleButtonGroup/index.ts
@@ -1,0 +1,3 @@
+import ToggleButtonGroupPage from "./ToggleButtonGroup";
+
+export default ToggleButtonGroupPage;

--- a/packages/react-components/src/pages/index.ts
+++ b/packages/react-components/src/pages/index.ts
@@ -11,6 +11,7 @@ import SelectPage from "./Select";
 import TagGroupPage from "./TagGroup";
 import TextAreaPage from "./TextArea";
 import TextFieldPage from "./TextField";
+import ToggleButtonGroupPage from "./ToggleButtonGroup";
 import SwitchPage from "./Switch";
 import TooltipPage from "./Tooltip";
 
@@ -28,6 +29,7 @@ export {
   TagGroupPage,
   TextAreaPage,
   TextFieldPage,
+  ToggleButtonGroupPage,
   SwitchPage,
   TooltipPage,
 };

--- a/packages/react-components/src/stories/ToggleButton.stories.tsx
+++ b/packages/react-components/src/stories/ToggleButton.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ToggleButton } from "../components";
+import { ToggleButtonProps } from "../components/ToggleButton";
+
+const meta = {
+  title: "Components/Toggle Button Group/Toggle Button",
+  component: ToggleButton,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    id: {
+      control: { type: "text" },
+      description: "Unique identifier for the button",
+    },
+    children: {
+      control: { type: "object" },
+      description: "Populates button text",
+    },
+  },
+} satisfies Meta<typeof ToggleButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ToggleButtonTemplate: Story = {
+  args: { children: ["Button text"], id: "1" },
+  render: ({ ...args }: ToggleButtonProps) => <ToggleButton {...args} />,
+};

--- a/packages/react-components/src/stories/ToggleButton.stories.tsx
+++ b/packages/react-components/src/stories/ToggleButton.stories.tsx
@@ -18,6 +18,11 @@ const meta = {
       control: { type: "object" },
       description: "Populates button text",
     },
+    type: {
+      control: { type: "radio" },
+      options: ["button", "submit", "reset"],
+      description: "The behavior of the button when used in an HTML form",
+    },
     size: {
       control: { type: "radio" },
       options: ["small", "medium"],
@@ -30,6 +35,10 @@ const meta = {
     isDisabled: {
       control: { type: "boolean" },
       description: "Whether a button is disabled",
+    },
+    autoFocus: {
+      control: { type: "boolean" },
+      description: "Whether the element should receive focus on render",
     },
     isSelected: {
       control: { type: "boolean" },

--- a/packages/react-components/src/stories/ToggleButton.stories.tsx
+++ b/packages/react-components/src/stories/ToggleButton.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { ToggleButton } from "../components";
+import { ToggleButton, SvgCheckCircleIcon } from "../components";
 import { ToggleButtonProps } from "../components/ToggleButton";
 
 const meta = {
@@ -12,11 +12,27 @@ const meta = {
   argTypes: {
     id: {
       control: { type: "text" },
-      description: "Unique identifier for the button",
+      description: "Unique identifier for the button (required)",
     },
     children: {
       control: { type: "object" },
       description: "Populates button text",
+    },
+    danger: {
+      control: { type: "boolean" },
+      description: "Applies a red colourway",
+    },
+    isDisabled: {
+      control: { type: "boolean" },
+      description: "Whether a button is disabled",
+    },
+    isSelected: {
+      control: { type: "boolean" },
+      description: "Whether the element should be selected (controlled)",
+    },
+    defaultSelected: {
+      control: { type: "boolean" },
+      description: "Whether the element should be selected (uncontrolled)",
     },
   },
 } satisfies Meta<typeof ToggleButton>;
@@ -25,6 +41,31 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const ToggleButtonTemplate: Story = {
-  args: { children: ["Button text"], id: "1" },
+  args: { children: ["Button text"], id: "1", isDisabled: false },
   render: ({ ...args }: ToggleButtonProps) => <ToggleButton {...args} />,
+};
+
+export const ToggleButtonWithIcon: Story = {
+  ...ToggleButtonTemplate,
+  args: {
+    children: [<SvgCheckCircleIcon />, "Button with icon"],
+  },
+};
+
+export const DangerToggleButton: Story = {
+  ...ToggleButtonTemplate,
+  args: { children: ["Danger colourway"], danger: true },
+};
+
+export const DefaultSelectedToggleButton: Story = {
+  ...ToggleButtonTemplate,
+  args: {
+    children: ["This button is selected by default"],
+    defaultSelected: true,
+  },
+};
+
+export const DisabledToggleButton: Story = {
+  ...ToggleButtonTemplate,
+  args: { children: ["This button is disabled"], isDisabled: true },
 };

--- a/packages/react-components/src/stories/ToggleButton.stories.tsx
+++ b/packages/react-components/src/stories/ToggleButton.stories.tsx
@@ -59,6 +59,14 @@ export const ToggleButtonTemplate: Story = {
   render: ({ ...args }: ToggleButtonProps) => <ToggleButton {...args} />,
 };
 
+export const SmallToggleButton: Story = {
+  ...ToggleButtonTemplate,
+  args: {
+    children: [<SvgCheckCircleIcon />, "Button with icon"],
+    size: "small",
+  },
+};
+
 export const ToggleButtonWithIcon: Story = {
   ...ToggleButtonTemplate,
   args: {

--- a/packages/react-components/src/stories/ToggleButton.stories.tsx
+++ b/packages/react-components/src/stories/ToggleButton.stories.tsx
@@ -18,6 +18,11 @@ const meta = {
       control: { type: "object" },
       description: "Populates button text",
     },
+    size: {
+      control: { type: "radio" },
+      options: ["small", "medium"],
+      description: "Sets button size",
+    },
     danger: {
       control: { type: "boolean" },
       description: "Applies a red colourway",

--- a/packages/react-components/src/stories/ToggleButton.stories.tsx
+++ b/packages/react-components/src/stories/ToggleButton.stories.tsx
@@ -4,7 +4,7 @@ import { ToggleButton, SvgCheckCircleIcon } from "../components";
 import { ToggleButtonProps } from "../components/ToggleButton";
 
 const meta = {
-  title: "Components/Toggle Button Group/Toggle Button",
+  title: "Components/Toggle buttons/Toggle button",
   component: ToggleButton,
   parameters: {
     layout: "centered",

--- a/packages/react-components/src/stories/ToggleButtonGroup.mdx
+++ b/packages/react-components/src/stories/ToggleButtonGroup.mdx
@@ -17,7 +17,10 @@ import * as ToggleButtonStories from "./ToggleButton.stories";
 
 # Toggle buttons
 
-<Subtitle></Subtitle>
+<Subtitle>
+  A toggle button sets a setting on or off, and can be used to switch between
+  different modes or states.
+</Subtitle>
 
 <Source
   code={`import { ToggleButton, ToggleButtonGroup } from "@bcgov/design-system-react-components";`}
@@ -35,6 +38,8 @@ This component is based on React Aria [ToggleButton](https://react-spectrum.adob
 
 ## Controls
 
+A `ToggleButton` can be used standalone, or multiple can be rendered inside a `ToggleButtonGroup`. `ToggleButton` and `ToggleButtonGroup` each have their own set of props.
+
 ### Toggle button
 
 <Primary of={ToggleButtonStories} />
@@ -46,3 +51,53 @@ This component is based on React Aria [ToggleButton](https://react-spectrum.adob
 <Controls of={ToggleButtonGroupStories.ToggleButtonGroupTemplate} />
 
 ## Configuration
+
+### Button size
+
+Set the `size` prop to `small` on a toggle button will render a button with less vertical padding:
+
+<Canvas of={ToggleButtonStories.SmallToggleButton} />
+
+### Orientation
+
+The `orientation` prop (defaults to `horizontal`) sets the visual layout and keyboard navigation direction of a `ToggleButtonGroup`:
+
+#### Horizontal
+
+<Canvas of={ToggleButtonGroupStories.HorizontalToggleButtonGroup} />
+
+#### Vertical
+
+<Canvas of={ToggleButtonGroupStories.VerticalToggleButtonGroup} />
+
+### Selection mode
+
+The `selectionMode` prop controls how many items within a `ToggleButtonGroup` can be selected (or toggled 'on') simultaneously.
+
+Use `selectedKeys` (controlled) or `defaultSelectedKeys` (uncontrolled) to pre-set selected options.
+
+#### Single
+
+By default, `selectionMode` is set to `single`. The active `ToggleButton` will be deactivated if another is selected:
+
+<Canvas of={ToggleButtonGroupStories.SingleSelect} />
+
+Use the `disallowEmptySelection` prop to control whether a selection is required, or if all options can be de-selected:
+
+<Canvas of={ToggleButtonGroupStories.SingleSelectDisallowEmpty} />
+
+#### Multiple
+
+If `selectionMode` is set to `multiple`, the user can toggle each value on or off discretely:
+
+<Canvas of={ToggleButtonGroupStories.MultipleSelect} />
+
+### Disabling items
+
+Set `isDisabled` on a `ToggleButton` to disable an individual option in a group:
+
+<Canvas of={ToggleButtonGroupStories.GroupWithDisabledOption} />
+
+Setting `isDisabled` on a `ToggleButtonGroup` will disable all options:
+
+<Canvas of={ToggleButtonGroupStories.DisabledToggleButtonGroup} />

--- a/packages/react-components/src/stories/ToggleButtonGroup.mdx
+++ b/packages/react-components/src/stories/ToggleButtonGroup.mdx
@@ -1,0 +1,48 @@
+{/* ToggleButtonGroup.mdx */}
+
+import {
+  Canvas,
+  Controls,
+  Meta,
+  Primary,
+  Source,
+  Story,
+  Subtitle,
+} from "@storybook/blocks";
+
+import * as ToggleButtonGroupStories from "./ToggleButtonGroup.stories";
+import * as ToggleButtonStories from "./ToggleButton.stories";
+
+<Meta title="Components/Toggle buttons" />
+
+# Toggle buttons
+
+<Subtitle></Subtitle>
+
+<Source
+  code={`import { ToggleButton, ToggleButtonGroup } from "@bcgov/design-system-react-components";`}
+  language="typescript"
+/>
+
+## Usage and resources
+
+Learn more about working with the toggle button and toggle button group components:
+
+- [Usage and best practice guidance](https://www2.gov.bc.ca/gov/content?id=FAE017578EED4A4980E2C1B8BE3415F9)
+- [View the text field component in Figma](https://www2.gov.bc.ca/gov/content?id=8E36BE1D10E04A17B0CD4D913FA7AC43#designers)
+
+This component is based on React Aria [ToggleButton](https://react-spectrum.adobe.com/react-aria/ToggleButton.html) and [ToggleButtonGroup](https://react-spectrum.adobe.com/react-aria/ToggleButtonGroup.html). Consult the React Aria documentation for additional technical information and a full list of supported props.
+
+## Controls
+
+### Toggle button
+
+<Primary of={ToggleButtonStories} />
+<Controls of={ToggleButtonStories.ToggleButtonTemplate} />
+
+### Toggle button group
+
+<Primary of={ToggleButtonGroupStories} />
+<Controls of={ToggleButtonGroupStories.ToggleButtonGroupTemplate} />
+
+## Configuration

--- a/packages/react-components/src/stories/ToggleButtonGroup.stories.tsx
+++ b/packages/react-components/src/stories/ToggleButtonGroup.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { ToggleButtonGroup } from "../components";
+import { ToggleButton, ToggleButtonGroup } from "../components";
 import { ToggleButtonGroupProps } from "../components/ToggleButtonGroup";
 
 const meta = {
@@ -10,9 +10,40 @@ const meta = {
     layout: "centered",
   },
   argTypes: {
+    label: {
+      control: { type: "text" },
+      description: "Provides a text label for a button group",
+    },
     children: {
       control: { type: "object" },
-      description: "Expects an array of Toggle Button components",
+      description: "Expects an array of `ToggleButton` components",
+    },
+    selectionMode: {
+      control: { type: "radio" },
+      options: ["single", "multiple"],
+      description:
+        "Sets whether multiple options can be selected at the same time",
+    },
+    disallowEmptySelection: {
+      control: { type: "boolean" },
+      description: "Whether the collection allows empty selection",
+    },
+    selectedKeys: {
+      control: { type: "object" },
+      description: "The currently selected keys in the collection (controlled)",
+    },
+    defaultSelectedKeys: {
+      control: { type: "object" },
+      description: "The initial selected keys in the collection (uncontrolled)",
+    },
+    orientation: {
+      control: { type: "radio" },
+      options: ["horizontal", "vertical"],
+      description: "Sets layout of button group",
+    },
+    isDisabled: {
+      control: { type: "boolean" },
+      description: "Whether all options are disabled",
     },
   },
 } satisfies Meta<typeof ToggleButtonGroup>;
@@ -21,8 +52,31 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const ToggleButtonGroupTemplate: Story = {
-  args: {},
+  args: {
+    children: [
+      <ToggleButton id="1">Button 1</ToggleButton>,
+      <ToggleButton id="2">Button 2</ToggleButton>,
+      <ToggleButton id="3">Button 3</ToggleButton>,
+    ],
+    selectionMode: "single",
+    orientation: "horizontal",
+    disallowEmptySelection: false,
+    isDisabled: false,
+  },
   render: ({ ...args }: ToggleButtonGroupProps) => (
     <ToggleButtonGroup {...args} />
   ),
+};
+
+export const DisabledToggleButtonGroup: Story = {
+  ...ToggleButtonGroupTemplate,
+  args: {
+    label: "This button group is disabled",
+    children: [
+      <ToggleButton id="1">Button 1</ToggleButton>,
+      <ToggleButton id="2">Button 2</ToggleButton>,
+      <ToggleButton id="3">Button 3</ToggleButton>,
+    ],
+    isDisabled: true,
+  },
 };

--- a/packages/react-components/src/stories/ToggleButtonGroup.stories.tsx
+++ b/packages/react-components/src/stories/ToggleButtonGroup.stories.tsx
@@ -4,7 +4,7 @@ import { ToggleButton, ToggleButtonGroup } from "../components";
 import { ToggleButtonGroupProps } from "../components/ToggleButtonGroup";
 
 const meta = {
-  title: "Components/Toggle Button Group/Toggle Button Group",
+  title: "Components/Toggle buttons/Toggle button group",
   component: ToggleButtonGroup,
   parameters: {
     layout: "centered",

--- a/packages/react-components/src/stories/ToggleButtonGroup.stories.tsx
+++ b/packages/react-components/src/stories/ToggleButtonGroup.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ToggleButtonGroup } from "../components";
+import { ToggleButtonGroupProps } from "../components/ToggleButtonGroup";
+
+const meta = {
+  title: "Components/Toggle Button Group/Toggle Button Group",
+  component: ToggleButtonGroup,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    children: {
+      control: { type: "object" },
+      description: "Expects an array of Toggle Button components",
+    },
+  },
+} satisfies Meta<typeof ToggleButtonGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ToggleButtonGroupTemplate: Story = {
+  args: {},
+  render: ({ ...args }: ToggleButtonGroupProps) => (
+    <ToggleButtonGroup {...args} />
+  ),
+};

--- a/packages/react-components/src/stories/ToggleButtonGroup.stories.tsx
+++ b/packages/react-components/src/stories/ToggleButtonGroup.stories.tsx
@@ -68,6 +68,87 @@ export const ToggleButtonGroupTemplate: Story = {
   ),
 };
 
+export const HorizontalToggleButtonGroup: Story = {
+  ...ToggleButtonGroupTemplate,
+  args: {
+    orientation: "horizontal",
+    children: [
+      <ToggleButton id="1">Button 1</ToggleButton>,
+      <ToggleButton id="2">Button 2</ToggleButton>,
+      <ToggleButton id="3">Button 3</ToggleButton>,
+    ],
+  },
+};
+
+export const VerticalToggleButtonGroup: Story = {
+  ...ToggleButtonGroupTemplate,
+  args: {
+    orientation: "vertical",
+    children: [
+      <ToggleButton id="1">Button 1</ToggleButton>,
+      <ToggleButton id="2">Button 2</ToggleButton>,
+      <ToggleButton id="3">Button 3</ToggleButton>,
+    ],
+  },
+};
+
+export const SingleSelect: Story = {
+  ...ToggleButtonGroupTemplate,
+  args: {
+    children: [
+      <ToggleButton id="light">Light mode</ToggleButton>,
+      <ToggleButton id="dark">Dark mode</ToggleButton>,
+    ],
+    selectionMode: "single",
+    defaultSelectedKeys: ["dark"],
+  },
+};
+
+export const SingleSelectDisallowEmpty: Story = {
+  ...ToggleButtonGroupTemplate,
+  args: {
+    children: [
+      <ToggleButton id="light">Light mode</ToggleButton>,
+      <ToggleButton id="dark">Dark mode</ToggleButton>,
+    ],
+    selectionMode: "single",
+    defaultSelectedKeys: ["dark"],
+    disallowEmptySelection: true,
+  },
+};
+
+export const MultipleSelect: Story = {
+  ...ToggleButtonGroupTemplate,
+  args: {
+    children: [
+      <ToggleButton id="bold">
+        <b>Bold</b>
+      </ToggleButton>,
+      <ToggleButton id="italic">
+        <i>Italic</i>
+      </ToggleButton>,
+      <ToggleButton id="underline">
+        <u>Underline</u>
+      </ToggleButton>,
+    ],
+    selectionMode: "multiple",
+    defaultSelectedKeys: ["bold", "underline"],
+  },
+};
+
+export const GroupWithDisabledOption: Story = {
+  ...ToggleButtonGroupTemplate,
+  args: {
+    children: [
+      <ToggleButton id="1">Button 1</ToggleButton>,
+      <ToggleButton id="2">Button 2</ToggleButton>,
+      <ToggleButton id="3" isDisabled>
+        Button 3 (disabled)
+      </ToggleButton>,
+    ],
+  },
+};
+
 export const DisabledToggleButtonGroup: Story = {
   ...ToggleButtonGroupTemplate,
   args: {


### PR DESCRIPTION
This PR adds two new components: `ToggleButton` and `ToggleButtonGroup` (implemented based on [RAC components of the same names](https://react-spectrum.adobe.com/react-aria/ToggleButton.html).)

A `ToggleButton` can be toggled between binary states (on/off):

Inactive:
![Screenshot 2025-01-20 at 16 50 09](https://github.com/user-attachments/assets/adee1ef3-97cc-4274-8ffe-69b3ab9968cc)

Active:
![Screenshot 2025-01-20 at 16 50 42](https://github.com/user-attachments/assets/0bb5d5ab-ae93-477d-8809-f59a8bd57817)

Multiple buttons can be rendered inside a `ToggleButtonGroup` to create more complex UIs (for example, choosing between mutually-exclusive options):

![Screenshot 2025-01-20 at 16 51 36](https://github.com/user-attachments/assets/669c8ef7-75ab-4423-8b46-d50e9d13a135)

Docs and examples are provided in Storybook. Leaving this PR in draft pending design review.