### PR TITLE
React Component v0.5.1

### DIFF
--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.5.1
+
+### Added
+
+- Added Heading, Text and Link components.
+
+This release uses:
+
+- `react-aria-components` v1.6.0
+
 ## 0.5.0
 
 This is a milestone release that contains the following new components:

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -83,12 +83,15 @@ export default function App() {
 | Footer                  | N/A                                                              |
 | Form                    | https://react-spectrum.adobe.com/react-aria/Form.html            |
 | Header                  | N/A                                                              |
+| Heading                 | https://react-spectrum.adobe.com/react-spectrum/Heading.html     |
 | InlineAlert             | N/A                                                              |
 | Modal                   | https://react-spectrum.adobe.com/react-aria/Modal.html           |
+| Link                    | https://react-spectrum.adobe.com/react-spectrum/Link.html        |
 | RadioGroup, Radio       | https://react-spectrum.adobe.com/react-aria/RadioGroup.html      |
 | Select                  | https://react-spectrum.adobe.com/react-aria/Select.html          |
 | Switch                  | https://react-spectrum.adobe.com/react-aria/Switch.html          |
 | TagGroup, TagList, Tag  | https://react-spectrum.adobe.com/react-aria/TagGroup.html        |
+| Text                    | https://react-spectrum.adobe.com/react-spectrum/Text.html        |
 | TextArea, TextField     | https://react-spectrum.adobe.com/react-aria/TextField.html       |
 | Tooltip, TooltipTrigger | https://react-spectrum.adobe.com/react-aria/Tooltip.html         |
 

--- a/packages/react-components/package-lock.json
+++ b/packages/react-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcgov/design-system-react-components",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@bcgov/design-tokens": "3.2.0",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/design-system-react-components",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "scripts": {
     "rollup": "rm -rf dist && rollup -c --bundleConfigAsCjs",


### PR DESCRIPTION
## 0.5.1

### Added

- Added Heading, Text and Link components.

This release uses:

- `react-aria-components` v1.6.0
- `react` ^16.14.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
- `react-dom` ^16.14.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0

Updated below Dev dependencies:
- Vite upgraded to 5.4.14
- Rollup upgraded to 4.32.1
- Cross Spawn upgraded to 7.0.6
- Nanoid upgraded to 3.3.8
- Storybook upgraded to 8.5.3