### PR TITLE
Add package-lock.json to Dockerfiles for Storybook and Vite apps

### DIFF
--- a/packages/react-components/Dockerfile.storybook
+++ b/packages/react-components/Dockerfile.storybook
@@ -9,7 +9,7 @@ ENV GITHUB_SHA=$GITHUB_SHA
 
 # Copy package.json and package-lock.json
 WORKDIR /app
-COPY package.json .
+COPY package.json package-lock.json ./
 COPY vite.config.ts .
 
 # Print npm config

--- a/packages/react-components/Dockerfile.vite
+++ b/packages/react-components/Dockerfile.vite
@@ -7,7 +7,7 @@ FROM node:lts-alpine AS build-stage
 
 # Copy package.json and package-lock.json
 WORKDIR /app
-COPY package.json .
+COPY package.json package-lock.json ./
 
 # Print npm config
 RUN npm config list


### PR DESCRIPTION
Attempt to fix outstanding errors in the build scripts for the Vite and Storybook apps, that are causing builds to fail. It adds `package-lock.json` alongside `package.json` to the files copied into a Docker container when those builds actions run.