### PR TITLE
Add .env to .gitignore

### DIFF
--- a/packages/react-components/.gitignore
+++ b/packages/react-components/.gitignore
@@ -19,6 +19,7 @@ vite-dist
 !.vscode/extensions.json
 .idea
 .DS_Store
+.env
 *.suo
 *.ntvs*
 *.njsproj


### PR DESCRIPTION
This PR adds `.env` to .gitignore to exclude it from version control.

This came up in the course of some some exploratory work on #430 — Figma's Code Connect CLI requires the use of a Figma personal access token which is stored locally in `.env`.