### PR TITLE
Add repository object to package.json

### DIFF
--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -3,7 +3,7 @@
   "version": "0.5.1",
   "repository": {
     "type": "git",
-    "url": "https://github.com/bcgov/design-system.git",
+    "url": "git+https://github.com/bcgov/design-system.git",
     "directory": "packages/react-components"
   },
   "type": "module",


### PR DESCRIPTION
This PR attempts to resolve the error that is [causing the npm publish job to fail](https://github.com/bcgov/design-system/actions/runs/19549499927/job/55976941599). 

db59f6f adds a `repository` object to `package.json` that specifies the source repo and directory, so that npm can establish provenance.

This change will also need to be mirrored in the design tokens `package.json` once we validate that it works.