### PR TITLE
Update GHA workflow for publishing React component library to npm

### DIFF
--- a/.github/workflows/publish_react_component_library.yaml
+++ b/.github/workflows/publish_react_component_library.yaml
@@ -1,4 +1,4 @@
-name: Publish @bcgov/design-system-react-components to npm @next
+name: Publish @bcgov/design-system-react-components to npm
 
 on:
   push:


### PR DESCRIPTION
This is a first pass at updating the GHA workflow that publishes the React component libraries to npm in order to get the `latest` job in a working state.

With this, there are still duplicated steps between the `publish-react-component-library-next` and `-latest` jobs and we could probably DRY these out a bit further, but I think this should work for a v0.5.2 release.

If this suffices, we should update the README in the React components package to indicate how the publishing for `next` and `latest` tags will work:

- `next` tags are automatically published to npm when a new commit is pushed to main (this happens when a PR is merged to main). Branch protection rules should be added if they are not already in place on this repo to prevent non-PR pushes to main.
  - This matches our current workflow, with very frequent releases on the `next` tag happening automatically so developers can test the latest version of the library.
- `latest` tag is published manually by creating and *publishing* a new release. The process for this looks like:
  - 1. `git tag` the commit the release is based on (like the last commit after updating main when you're about to do a release)
  - 2. pushing the new tag to GitHub
  - 3. in the GitHub web UI, create a release
  - 4. add notes to the new release
  - 5. publish the new release, which triggers the GitHub Actions workflow to run.
  - This new workflow means the product owner can do a manual release of the `latest` (production) version of the library by pushing a button in the web UI instead of relying on a developer to publish manually.

The benefit of this new approach is we get provenance information in npm because all of our publishing will be happening in GitHub Actions. Interested parties can trace a release in npm back to a GitHub Action workflow run on this repo.

One downside I can see with this is when you cut the new release, if the action run doesn't complete, you have to figure out why and fix it while you're in an awkward state where your GitHub repo indicates there is a new release, but it's not yet installable from npm. Hopefully all of testing that happens along the way will prevent this, but for the first run... :shrug: