### PR TITLE
Fix release tag matching in GHA to publish to npm

### DIFF
--- a/.github/workflows/publish_react_component_library.yaml
+++ b/.github/workflows/publish_react_component_library.yaml
@@ -75,7 +75,7 @@ jobs:
     # Publish a `latest` version only when a release is published that targets
     # the React components package via a tag like:
     # @bcgov/design-system-react-components@v1.2.3
-    if: ${{ github.event_name == 'release' && startsWith(github.event.release.tag_name, '@bcgov/design-system-react-components') }}
+    if: ${{ github.event_name == 'release' && contains(github.event.release.tag_name, 'bcgov/design-system-react-components') }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This PR changes the criterion that [this GHA](https://github.com/bcgov/design-system/blob/main/.github/workflows/publish_react_component_library.yaml) uses to trigger a publish to npm.

The workflow now triggers when it detects a release tag name containing `bcgov/design-system-react-components`.