### PR TITLE
remove old publish script from workflow and properly target dist folder

### DIFF
--- a/.github/workflows/publish_design_tokens.yaml
+++ b/.github/workflows/publish_design_tokens.yaml
@@ -72,8 +72,8 @@ jobs:
         run: echo "//registry.npmjs.org/" > ~/.npmrc
 
       - name: Publish to npm @next
-        run: npm run publish-npm-package -- --access public --tag next
-        working-directory: ./packages/design-tokens
+        run: npm publish --tag next
+        working-directory: ./packages/design-tokens/dist
 
   publish-design-tokens-latest:
     name: Publish @bcgov/design-tokens@latest
@@ -113,4 +113,4 @@ jobs:
 
       - name: Publish to npm @latest
         run: npm publish --tag latest
-        working-directory: ./packages/design-tokens
+        working-directory: ./packages/design-tokens/dist


### PR DESCRIPTION
This PR attempts to fix [this job failure](https://github.com/bcgov/design-system/actions/runs/19770090338/job/56652178421#step:11:40) in the GHA that publishes new versions of the design tokens library.

It removes an old script (`run-publish-npm-package`) from the workflow, and updates the publish steps in both the `next` and `latest` jobs to target the correct subfolder (`/dist`).