### PR TITLE
npm publishing workflow uses push instead of PR

### DIFF
--- a/.github/workflows/publish_react_component_library.yaml
+++ b/.github/workflows/publish_react_component_library.yaml
@@ -42,20 +42,20 @@ jobs:
 
       # Use `jq` to change the package.json version to look like:
       #
-      #   <version in package.json>-pr<PR # that caused the workflow run>
+      #   <version in package.json>-<commit # that caused the workflow run>
       #
-      # So package.json version v1.2.3 with a run caused by merging PR #456 to
+      # So package.json version v1.2.3 with a run caused by pushing to
       # `main` causes the version of the package on npm to look like:
       #
-      #   1.2.3-pr456
+      #   1.2.3-SHA#
       #
-      # This is to ensure that it's easy to map an npm version to a particular PR.
+      # This is to ensure that it's easy to map an npm version to a particular commit.
       #
       - name: Update version in package.json
         run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
+          COMMIT=${GITHUB_SHA}
           CURRENT_VERSION=$(jq -r '.version' package.json)
-          NEW_VERSION="${CURRENT_VERSION}-pr${PR_NUMBER}"
+          NEW_VERSION="${CURRENT_VERSION}-commit${COMMIT}"
           jq --arg new_version "$NEW_VERSION" '.version = $new_version' package.json > tmp.json && mv tmp.json package.json
         shell: bash
         working-directory: ./packages/react-components


### PR DESCRIPTION
This PR does three things, to try and resolve ongoing issues with the npm publishing workflow:

1. 0dee46a79b0a10f836a9487d3f3f7c241d755ac3 reverts to using `push` as the trigger for the `@next` publishing job
2. 6ea8792f3b8fdad4bcd15923ce5a30d57aa61878 updates the labelling for `@next` packages to use the commit SHA, because `github.event.pull_request.number` will always evaluate to empty when using `push` as the trigger
3. c940f2202107af47d2d6c4b6691fe1308b0ce7e8 adds `workflow_dispatch` as a trigger, enabling us to manually run the workflow as a fallback