### PR TITLE
Fix typo in npm publishing GHA

### DIFF
--- a/.github/workflows/publish_react_component_library.yaml
+++ b/.github/workflows/publish_react_component_library.yaml
@@ -3,7 +3,7 @@ name: Publish @bcgov/design-system-react-components to npm
 on:
   pull_request:
     paths:
-      - packages/design-system-react-components/**
+      - packages/react-components/**
     branches: [main]
     types: [closed]
   release:


### PR DESCRIPTION
This PR fixes a typo in the npm publishing workflow, that prevented the PR condition from being met to trigger a publish to `@next`.