### PR TITLE
TextArea and TextField use correct disabled styling

### DIFF
--- a/packages/react-components/src/components/TextArea/TextArea.css
+++ b/packages/react-components/src/components/TextArea/TextArea.css
@@ -83,13 +83,10 @@
 }
 
 /* Disabled and invalid states */
-.bcds-react-aria-TextArea[data-disabled]
-  > .bcds-react-aria-TextArea--Container {
+.bcds-react-aria-TextArea[data-disabled] > .bcds-react-aria-TextArea--Container,
+.bcds-react-aria-TextArea[data-disabled] .bcds-react-aria-TextArea--Input {
   background: var(--surface-color-forms-disabled);
-  cursor: not-allowed;
-}
-
-.bcds-react-aria-TextArea--Input[data-disabled] {
+  color: var(--typography-color-placeholder);
   cursor: not-allowed;
 }
 
@@ -100,14 +97,8 @@
   background: var(--surface-color-forms-default);
 }
 
-.bcds-react-aria-TextArea[data-readonly]
-  > .bcds-react-aria-TextArea--Container {
-  background: var(--surface-color-forms-disabled);
-}
-
-.bcds-react-aria-TextArea[data-readonly]
-  > .bcds-react-aria-TextArea--Container
-  > .bcds-react-aria-TextArea--Input {
+.bcds-react-aria-TextArea[data-readonly] > .bcds-react-aria-TextArea--Container,
+.bcds-react-aria-TextArea[data-readonly] .bcds-react-aria-TextArea--Input {
   background: var(--surface-color-forms-disabled);
 }
 

--- a/packages/react-components/src/components/TextField/TextField.css
+++ b/packages/react-components/src/components/TextField/TextField.css
@@ -88,12 +88,9 @@
 /* Disabled and invalid states */
 
 .bcds-react-aria-TextField[data-disabled]
-  > .bcds-react-aria-TextField--container {
+  > .bcds-react-aria-TextField--container,
+.bcds-react-aria-TextField[data-disabled] .bcds-react-aria-TextField--Input {
   background: var(--surface-color-forms-disabled);
-  cursor: not-allowed;
-}
-
-.bcds-react-aria-TextField--Input[data-disabled] {
   color: var(--typography-color-placeholder);
   cursor: not-allowed;
 }
@@ -107,7 +104,8 @@
 }
 
 .bcds-react-aria-TextField[data-readonly]
-  > .bcds-react-aria-TextField--container {
+  > .bcds-react-aria-TextField--container,
+.bcds-react-aria-TextField[data-readonly] .bcds-react-aria-TextField--Input {
   background: var(--surface-color-forms-disabled);
 }
 


### PR DESCRIPTION
This PR fixes the issue identified in #585. When a TextField or TextArea are disabled, the internal `<input>` now receives the correct background colour, as does any text in the field:

TextField:
<img width="353" height="146" alt="Screenshot 2025-12-16 at 1 08 48 PM" src="https://github.com/user-attachments/assets/f5fbbf5d-ab6a-483f-b9aa-95b7803eaa54" />

TextArea:
<img width="288" height="149" alt="Screenshot 2025-12-16 at 1 08 26 PM" src="https://github.com/user-attachments/assets/14e33a70-5990-4f24-9f3e-380539b9a8ed" />
