### PR TITLE
Vite Dockerfile copies Storybook files for build

### DIFF
--- a/packages/react-components/Dockerfile.vite
+++ b/packages/react-components/Dockerfile.vite
@@ -22,6 +22,10 @@ COPY tsconfig.vite.json ./
 COPY vite.config.ts ./
 COPY src ./src
 
+# Storybook files are included because they are referenced in `vite.config.ts`
+# and required for the build to succeed.
+COPY .storybook ./.storybook
+
 # Run Vite build script, which places built files in /app/vite-dist
 RUN npm run vite-build
 


### PR DESCRIPTION
This attempts to fix the [broken build](https://github.com/bcgov/design-system/actions/runs/20278942559) from #560.

As part of the new Vite configuration for `vitest`, the [`test` portion of the configuration](https://github.com/bcgov/design-system/blob/main/packages/react-components/vite.config.ts#L27-L52) now references the Storybook files in `.storybook`. These are not currently being included in the build stage of `Dockerfile.vite`. As a result, the `vite build` command fails:

```
#20 [build-stage 11/11] RUN npm run vite-build
#20 0.261 
#20 0.261 > @bcgov/design-system-react-components@0.5.2 vite-build
#20 0.261 > tsc && vite build
#20 0.261 
#20 5.778 vite v7.2.4 building client environment for production...
#20 5.825 file:///app/node_modules/storybook/dist/_node-chunks/chunk-6XH4P37X.js:9991
#20 5.825     throw new MainFileMissingError({ location: configDir });
#20 5.825           ^
#20 5.825 
#20 5.825 SB_CORE-SERVER_0006 (MainFileMissingError): No configuration files have been found in your configDir: /app/.storybook.
#20 5.825 Storybook needs a "main.js" file, please add it.
#20 5.825 
#20 5.825 You can pass a --config-dir flag to tell Storybook, where your main.js file is located at.
#20 5.825 
#20 5.825 More info: https://storybook.js.org/docs/configure?ref=error
#20 5.825 
#20 5.825     at validateConfigurationFiles (file:///app/node_modules/storybook/dist/_node-chunks/chunk-6XH4P37X.js:9991:11)
#20 5.825     at async loadMainConfig (file:///app/node_modules/storybook/dist/_node-chunks/chunk-6XH4P37X.js:11667:3)
#20 5.825     at async loadStorybook (file:///app/node_modules/storybook/dist/core-server/index.js:7262:16)
#20 5.825     at async storybookTest (file:///app/node_modules/@storybook/addon-vitest/dist/vitest-plugin/index.js:2400:20) {
#20 5.825   data: { location: '/app/.storybook' },
#20 5.825   fromStorybook: true,
#20 5.825   isHandledError: false,
#20 5.825   subErrors: [],
#20 5.825   category: 'CORE-SERVER',
#20 5.825   documentation: 'https://storybook.js.org/docs/configure?ref=error',
#20 5.825   code: 6,
#20 5.825   _name: 'MainFileMissingError'
#20 5.825 }
#20 5.825 
#20 5.825 Node.js v24.12.0
#20 ERROR: process "/bin/sh -c npm run vite-build" did not complete successfully: exit code: 1
------
```

We could solve this a few ways:

1. By adding some branching logic into the Vite config file which would check for an environment variable we set specifically for the Vite kitchen sink app build. Then exclude the `test` configuration entirely based on the presence of this variable.
2. Include a whole separate simplified version of the Vite config when building the Vite app.
3. Copy the Storybook files in the Vite app Dockerfile and keep using the same Vite config for both Storybook and the Vite app.

I opted for option 3 because it's the simplest and has no effect on the final image size spit out by the Dockerfile build in this case (~57Mb).