### PR TITLE
Update dist version of design tokens package.json

### DIFF
--- a/packages/design-tokens/dist/package.json
+++ b/packages/design-tokens/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/design-tokens",
-  "version": "3.2.0",
+  "version": "3.1.1",
   "description": "Design tokens for B.C. Design System",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR updates the version of `package.json` in the `dist` folder of the design tokens package to add the `repository` object needed to publish to npm with OIDC (mirroring the change made to the main version of this file in #569).

**Note**: the version number in this file did not get properly updated the last time a release was done. It should have been incremented to match the main `package.json` via the `prepare-npm-package` script. I will monitor whether that action runs properly and updates that value once this PR is merged — may require further investigation.