### PR TITLE
Apply focus styling more consistently

### DIFF
--- a/packages/react-components/src/components/Checkbox/Checkbox.css
+++ b/packages/react-components/src/components/Checkbox/Checkbox.css
@@ -32,7 +32,7 @@
 }
 
 /* Focus */
-.bcds-react-aria-Checkbox[data-focused] > .checkbox {
+.bcds-react-aria-Checkbox[data-focus-visible] > .checkbox {
   outline: solid var(--layout-border-width-medium)
     var(--surface-color-border-active);
   outline-offset: var(--layout-margin-hair);

--- a/packages/react-components/src/components/Select/Select.css
+++ b/packages/react-components/src/components/Select/Select.css
@@ -63,7 +63,7 @@
 .bcds-react-aria-Select--Button[data-hovered] {
   border-color: var(--surface-color-border-dark);
 }
-.bcds-react-aria-Select--Button[data-focused] {
+.bcds-react-aria-Select--Button[data-focus-visible] {
   border-color: var(--surface-color-border-active);
   outline: solid var(--layout-border-width-medium)
     var(--surface-color-border-active);

--- a/packages/react-components/src/components/Tag/Tag.css
+++ b/packages/react-components/src/components/Tag/Tag.css
@@ -88,7 +88,7 @@
 }
 
 /* Focused */
-.bcds-react-aria-Tag[data-focused] {
+.bcds-react-aria-Tag[data-focus-visible] {
   outline: var(--layout-border-width-medium) solid
     var(--surface-color-border-active);
   outline-offset: var(--layout-margin-hair);

--- a/packages/react-components/src/components/TextArea/TextArea.css
+++ b/packages/react-components/src/components/TextArea/TextArea.css
@@ -71,6 +71,9 @@
 
 .bcds-react-aria-TextArea--Container:has(
     > .bcds-react-aria-TextArea--Input[data-focused]
+  ),
+.bcds-react-aria-TextArea--Container:has(
+    > .bcds-react-aria-TextArea--Input[data-focused][data-hovered]
   ) {
   border-color: var(--surface-color-border-active);
 }

--- a/packages/react-components/src/components/TextArea/TextArea.css
+++ b/packages/react-components/src/components/TextArea/TextArea.css
@@ -69,7 +69,15 @@
   outline: none;
 }
 
-.bcds-react-aria-TextArea--Container:focus-within {
+.bcds-react-aria-TextArea--Container:has(
+    > .bcds-react-aria-TextArea--Input[data-focused]
+  ) {
+  border-color: var(--surface-color-border-active);
+}
+
+.bcds-react-aria-TextArea--Container:has(
+    > .bcds-react-aria-TextArea--Input[data-focus-visible]
+  ) {
   border-radius: var(--layout-border-radius-large);
   border: var(--layout-border-width-small) solid
     var(--surface-color-border-active);
@@ -78,7 +86,9 @@
   outline-offset: var(--layout-margin-hair);
 }
 
-.bcds-react-aria-TextArea--Container:hover {
+.bcds-react-aria-TextArea--Container:has(
+    > .bcds-react-aria-TextArea--Input[data-hovered]
+  ) {
   border-color: var(--surface-color-border-dark);
 }
 

--- a/packages/react-components/src/components/TextField/TextField.css
+++ b/packages/react-components/src/components/TextField/TextField.css
@@ -74,6 +74,9 @@
 
 .bcds-react-aria-TextField--container:has(
     > .bcds-react-aria-TextField--Input[data-focused]
+  ),
+.bcds-react-aria-TextField--container:has(
+    > .bcds-react-aria-TextField--Input[data-focused][data-hovered]
   ) {
   border-color: var(--surface-color-border-active);
 }

--- a/packages/react-components/src/components/TextField/TextField.css
+++ b/packages/react-components/src/components/TextField/TextField.css
@@ -72,7 +72,15 @@
   outline: none;
 }
 
-.bcds-react-aria-TextField--container:focus-within {
+.bcds-react-aria-TextField--container:has(
+    > .bcds-react-aria-TextField--Input[data-focused]
+  ) {
+  border-color: var(--surface-color-border-active);
+}
+
+.bcds-react-aria-TextField--container:has(
+    > .bcds-react-aria-TextField--Input[data-focus-visible]
+  ) {
   border-radius: var(--layout-border-radius-large);
   border: var(--layout-border-width-small) solid
     var(--surface-color-border-active);


### PR DESCRIPTION
This PR makes changes to 5 components to handle focus states more consistently. Affected components are:

- Checkbox
- Select
- Tag
- TextArea
- TextField

The key change is to the conditions for applying the offset focus ring, like this:

<img width="267" height="122" alt="Screenshot 2025-12-17 at 2 53 47 PM" src="https://github.com/user-attachments/assets/10dc5717-b62c-4ca3-a11a-5fca1a91ef8b" />

In these (mostly older) components, we previously used the RAC data attribute `[data-focused]` to apply this style. This triggers whenever the element is in focus, whether via keyboard or via the user clicking into it, etc.

This change updates these components to instead use the attribute `[data-focus-visible]`, which applies more narrowly **only** when the element is keyboard-focused. This is the approach we have adopted for most of our more recent components.

TextField in non-keyboard focus (`[data-focused]`):
<img width="329" height="131" alt="Screenshot 2025-12-17 at 2 53 08 PM" src="https://github.com/user-attachments/assets/c55ee29b-ba45-4619-b775-4dcd8ae031cb" />

TextField in keyboard focus (`[data-focus-visible]`):
<img width="334" height="126" alt="Screenshot 2025-12-17 at 2 52 59 PM" src="https://github.com/user-attachments/assets/0642a5a4-5249-46f6-aebf-f80f47a0363e" />

This change preserves the functionality of clearly indicating where focus is for users navigating via keyboard, but reduces visual load for other users (letting hover, border and cursor visual cues handle the task.)