### PR TITLE
Change how npm registry URL is set

### DIFF
--- a/.github/workflows/publish_react_component_library.yaml
+++ b/.github/workflows/publish_react_component_library.yaml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.GITHUB_NVMRC_VERSION }}
+          registry-url: "https://registry.npmjs.org/"
 
       - name: Install dependencies
         run: npm install
@@ -63,9 +64,6 @@ jobs:
       - name: Build components for publishing
         run: npm run build
         working-directory: ./packages/react-components
-
-      - name: Set up .npmrc configuration
-        run: echo "//registry.npmjs.org/" > ~/.npmrc
 
       - name: Publish to npm @next
         run: npm publish --tag next


### PR DESCRIPTION
This PR makes a small change to simplify the GHA used to publish `design-system-react-components` to npm. It mirrors one of the changes made in #592. 

The `registry-url` value is now set via `setup-node`, instead of in a discrete step later in the workflow. 