### PR TITLE
Fix component name in catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,7 +1,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: b.c.-design-system
+  name: bc-design-system
   title: B.C. Design System
   description: The B.C. Design System helps public sector design and development
     teams build consistent, accessible products.


### PR DESCRIPTION
The `metadata.name` value can't have periods in it. I've removed the periods. The value is used in things like  "slugs", but doesn't have any bearing on the "human readable" name.