### PR TITLE
Button: add visible pressed state

### DIFF
--- a/packages/react-components/src/components/Button/Button.css
+++ b/packages/react-components/src/components/Button/Button.css
@@ -74,7 +74,7 @@
 /* Variant - Primary */
 .bcds-react-aria-Button.primary {
   background: var(--surface-color-primary-button-default);
-  color: var(--icons-color-primary-invert);
+  color: var(--typography-color-primary-invert);
 }
 .bcds-react-aria-Button.primary.danger {
   background-color: var(--surface-color-primary-danger-button-default);
@@ -102,7 +102,8 @@
 /* Variant - Secondary */
 .bcds-react-aria-Button.secondary {
   background-color: var(--surface-color-secondary-button-default);
-  border: 1px solid var(--surface-color-border-dark);
+  border: var(--layout-border-width-small) solid
+    var(--surface-color-border-dark);
   color: var(--typography-color-primary);
 }
 .bcds-react-aria-Button.secondary.danger {


### PR DESCRIPTION
This PR addresses the issues identified by @ty2k in #632, by adding additional styling when a button is pressed (using the `[data-pressed]` attribute).

ba9b3c042b4169b9e5dbbf675f737eb13480e7fe also does some cleanup to replace various hardcoded values with tokenized ones.

Primary Button Large is pressed:
<img width="633" height="213" alt="Screenshot 2026-02-18 at 9 25 32 AM" src="https://github.com/user-attachments/assets/f8abfdd2-7fcf-423f-a1de-f4b389cf7464" />

Secondary Button Medium is pressed:
<img width="669" height="203" alt="Screenshot 2026-02-18 at 9 23 03 AM" src="https://github.com/user-attachments/assets/04cb6edf-c9df-4f77-88ec-c5d69ecf0d8f" />

Primary Button Medium is pressed:
<img width="635" height="205" alt="Screenshot 2026-02-18 at 9 23 07 AM" src="https://github.com/user-attachments/assets/9ab001af-01f6-4bfd-92b4-a8ac6f722299" />