### PR TITLE
Button: add min-width and min-height

### DIFF
--- a/packages/react-components/src/components/Button/Button.css
+++ b/packages/react-components/src/components/Button/Button.css
@@ -1,11 +1,10 @@
 .bcds-react-aria-Button {
   display: inline-flex;
   align-items: center;
-  justify-content: space-around;
+  justify-content: center;
   gap: var(--layout-padding-small);
   min-height: 24px;
   min-width: 24px;
-  box-sizing: border-box;
   border: none;
   border-radius: var(--layout-border-radius-medium);
   cursor: pointer;


### PR DESCRIPTION
This PR addresses the issue identified by @ty2k in #633. With the introduction of the `xsmall` button variant in 0.5.2, we inadvertently made it possible to violate [WCAG SC 2.5.8](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html). An `xsmall` button with a single-character label fails to meet the minimum target size:

<img width="620" height="135" alt="Screenshot 2026-02-18 at 11 33 05 AM" src="https://github.com/user-attachments/assets/50d14b41-1e6c-48fa-99bc-6ec695c35389" />

This change resolves this by setting `min-width` and `min-height` at the top level of the component. It also cleans up some inconsistency/duplication in various rules.