### PR TITLE
Automate Storybook publishing

### DIFF
--- a/.github/workflows/build_react_component_library_apps.yaml
+++ b/.github/workflows/build_react_component_library_apps.yaml
@@ -7,6 +7,8 @@ on:
     paths:
       - packages/react-components/**
     branches: [main]
+  release:
+    types: [published]
   workflow_dispatch:
 
 # Cancel any currently running builds to save GitHub Actions hours.
@@ -15,8 +17,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  storybook-build-and-push:
-    name: Storybook build and push
+  storybook-build-and-push-dev:
+    name: Storybook build and push to dev environment
     runs-on: ubuntu-latest
     if: github.repository == 'bcgov/design-system'
 
@@ -46,6 +48,39 @@ jobs:
       - name: Tag and push Docker image
         run: |
           docker tag design-system-react-components-storybook:latest image-registry.apps.silver.devops.gov.bc.ca/${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE }}-tools/design-system-react-components-storybook:develop
+          docker push image-registry.apps.silver.devops.gov.bc.ca/${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE }}-tools/design-system-react-components-storybook --all-tags
+
+  storybook-build-and-push-prod:
+    name: Storybook build and push to production
+    if: ${{ github.event_name == 'release' && contains(github.event.release.tag_name, 'bcgov/design-system-react-components') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
+
+      - name: Build image with docker build
+        run: docker build ./packages/react-components/ -f ./packages/react-components/Dockerfile.storybook -t design-system-react-components-storybook:latest --build-arg GITHUB_SHA=${{ github.sha }}
+
+      - name: Login to OpenShift Silver image registry
+        uses: docker/login-action@v3
+        with:
+          registry: image-registry.apps.silver.devops.gov.bc.ca
+          # This refers to the serviceaccount name alone, not the fully qualified
+          # value that comes out of `oc whoami` when logged in as the SA.
+          # Ex: For `system:serviceaccount:<name space>:<service account name>`,
+          # just use `<service account name>`.
+          username: ${{ secrets.OPENSHIFT_SILVER_SERVICEACCOUNT_USERNAME }}
+          password: ${{ secrets.OPENSHIFT_SILVER_SERVICEACCOUNT_TOKEN }}
+
+      - name: Tag and push Docker image
+        run: |
+          docker tag design-system-react-components-storybook:latest image-registry.apps.silver.devops.gov.bc.ca/${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE }}-tools/design-system-react-components-storybook:production
           docker push image-registry.apps.silver.devops.gov.bc.ca/${{ secrets.OPENSHIFT_SILVER_LICENSE_PLATE }}-tools/design-system-react-components-storybook --all-tags
 
   vite-build-and-push:

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -129,9 +129,9 @@ Storybook stories live in `./src/stories`.
 
 Run `npm run storybook-dev` to access the Storybook instance for the component library.
 
-New versions of Storybook are automatically built in a GitHub Actions workflow and deployed in the `-dev` namespace in the OpenShift Silver cluster. See `.github/build_react_component_library_apps.yaml`.
+New versions of Storybook are automatically built in a GitHub Actions workflow and deployed in the `-dev` namespace in the OpenShift Silver cluster. New builds are automatically deployed to the `-prod` namespace when a GitHub release is published. See `.github/build_react_component_library_apps.yaml`.
 
-To deploy a new version of Storybook into `-test` or `-prod`, log in to the OpenShift CLI and run:
+To manually deploy a new version of Storybook into `-test` or `-prod`, log in to the OpenShift CLI and run:
 
 ```sh
 # Create a new layer in the `test` ImageStream from the latest `develop` image:


### PR DESCRIPTION
This PR removes the last remaining manual step from the publish workflow for `@bcgov/design-system-react-components`.

It forks the existing `storybook-build-and-push` job in [build_react_component_library_apps.yaml](https://github.com/bcgov/design-system/blob/main/.github/workflows/build_react_component_library_apps.yaml) into two separate paths:

1. `storybook-build-and-push-dev`: builds and deploys to OpenShift dev environment on push (existing behaviour)
2. `storybook-build-and-push-prod`: builds and deploys to OpenShift production environment when a release is published on GitHub (mirroring trigger condition in [publish_react_component_library.yaml](https://github.com/bcgov/design-system/blob/main/.github/workflows/publish_react_component_library.yaml))

This means that the latest build of Storybook will automatically be deployed to [designsystem.gov.bc.ca/react-components/](https://designsystem.gov.bc.ca/react-components/) simultaneously with a new release being published to npm, removing the need to manually deploy new builds.