### PR TITLE
Fix typo in background-color token value for InlineAlert success variant

### DIFF
--- a/packages/react-components/src/components/InlineAlert/InlineAlert.css
+++ b/packages/react-components/src/components/InlineAlert/InlineAlert.css
@@ -80,7 +80,7 @@
 
 /* Success variant */
 .bcds-Inline-Alert.success {
-  background-color: var(--suport-surface-color-success);
+  background-color: var(--support-surface-color-success);
   border: var(--layout-border-width-small) solid
     var(--support-border-color-success);
   border-radius: var(--layout-border-radius-medium);


### PR DESCRIPTION
Current, missing background color:
<img width="2032" height="1167" alt="Screen Shot 2026-04-21 at 9 44 57 PM" src="https://github.com/user-attachments/assets/3bab39f6-eb48-47b5-acf1-16bda0b6d566" />

After fixing the typo, light green background color:
<img width="2032" height="1167" alt="Screen Shot 2026-04-21 at 9 45 16 PM" src="https://github.com/user-attachments/assets/b3dd3c2d-f573-494b-ac20-1c773e64c3d6" />
