### PR TITLE
Publish npm packages to GitHub registry

### DIFF
--- a/.github/workflows/publish_react_component_library.yaml
+++ b/.github/workflows/publish_react_component_library.yaml
@@ -15,12 +15,10 @@ permissions:
   packages: write
 
 jobs:
-  publish-react-component-library-next:
-    name: Publish @bcgov/design-system-react-components@next
-    # Publish a `next` version on PR merge to main branch.
+  publish-npm-next:
+    # Publish a `next` version to npm on PR merge to `main`
     if: ${{ github.event.pull_request.merged == true && github.repository == 'bcgov/design-system' }}
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -42,17 +40,7 @@ jobs:
       - name: Install jq
         run: sudo apt-get install -y jq
 
-      # Use `jq` to change the package.json version to look like:
-      #
-      #   <version in package.json>-pr<PR # that caused the workflow run>
-      #
-      # So package.json version v1.2.3 with a run caused by merging PR #456 to
-      # `main` causes the version of the package on npm to look like:
-      #
-      #   1.2.3-pr456
-      #
-      # This is to ensure that it's easy to map an npm version to a particular PR.
-      #
+      # Append PR number to version number in package.json
       - name: Update version in package.json
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
@@ -67,7 +55,19 @@ jobs:
         working-directory: ./packages/react-components
 
       - name: Publish to npm @next
-        run: npm publish --tag next
+        run: npm publish --tag next --provenance
+        working-directory: ./packages/react-components
+
+  publish-github-packages-next:
+    # Publish a `next` version to GitHub Packages on PR merge to `main`
+    if: ${{ github.event.pull_request.merged == true && github.repository == 'bcgov/design-system' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Read .nvmrc
+        run: echo "GITHUB_NVMRC_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV
         working-directory: ./packages/react-components
 
       - name: Set up Node.js for GitHub Packages
@@ -77,20 +77,37 @@ jobs:
           registry-url: "https://npm.pkg.github.com/"
           scope: "@bcgov"
 
+      - name: Install dependencies
+        run: npm install
+        working-directory: ./packages/react-components
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      # Append PR number to version number in package.json
+      - name: Update version in package.json
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          CURRENT_VERSION=$(jq -r '.version' package.json)
+          NEW_VERSION="${CURRENT_VERSION}-pr${PR_NUMBER}"
+          jq --arg new_version "$NEW_VERSION" '.version = $new_version' package.json > tmp.json && mv tmp.json package.json
+        shell: bash
+        working-directory: ./packages/react-components
+
+      - name: Build components for publishing
+        run: npm run build
+        working-directory: ./packages/react-components
+
       - name: Publish to GitHub Packages @next
         run: npm publish --tag next --registry=https://npm.pkg.github.com/
         working-directory: ./packages/react-components
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  publish-react-component-library-latest:
-    name: Publish @bcgov/design-system-react-components@latest
-    # Publish a `latest` version only when a release is published that targets
-    # the React components package via a tag like:
-    # @bcgov/design-system-react-components@v1.2.3
+  publish-npm-latest:
+    # Publish a `latest` version to npm when a release is published that targets `@bcgov/design-system-react-components`
     if: ${{ github.event_name == 'release' && contains(github.event.release.tag_name, 'bcgov/design-system-react-components') }}
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -103,6 +120,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.GITHUB_NVMRC_VERSION }}
+          registry-url: "https://registry.npmjs.org/"
 
       - name: Install dependencies
         run: npm install
@@ -112,11 +130,20 @@ jobs:
         run: npm run build
         working-directory: ./packages/react-components
 
-      - name: Set up .npmrc configuration
-        run: echo "//registry.npmjs.org/" > ~/.npmrc
-
       - name: Publish to npm @latest
-        run: npm publish --tag latest
+        run: npm publish --tag latest --provenance
+        working-directory: ./packages/react-components
+
+  publish-github-packages-latest:
+    # Publish a `latest` version to GitHub Packages when a release is published that targets `@bcgov/design-system-react-components`
+    if: ${{ github.event_name == 'release' && contains(github.event.release.tag_name, 'bcgov/design-system-react-components') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Read .nvmrc
+        run: echo "GITHUB_NVMRC_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV
         working-directory: ./packages/react-components
 
       - name: Set up Node.js for GitHub Packages
@@ -125,6 +152,14 @@ jobs:
           node-version: ${{ env.GITHUB_NVMRC_VERSION }}
           registry-url: "https://npm.pkg.github.com/"
           scope: "@bcgov"
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: ./packages/react-components
+
+      - name: Build components for publishing
+        run: npm run build
+        working-directory: ./packages/react-components
 
       - name: Publish to GitHub Packages @latest
         run: npm publish --tag latest --registry=https://npm.pkg.github.com/

--- a/.github/workflows/publish_react_component_library.yaml
+++ b/.github/workflows/publish_react_component_library.yaml
@@ -12,6 +12,7 @@ on:
 permissions:
   id-token: write # Required for OIDC
   contents: read
+  packages: write
 
 jobs:
   publish-react-component-library-next:
@@ -69,6 +70,19 @@ jobs:
         run: npm publish --tag next
         working-directory: ./packages/react-components
 
+      - name: Set up Node.js for GitHub Packages
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.GITHUB_NVMRC_VERSION }}
+          registry-url: "https://npm.pkg.github.com/"
+          scope: "@bcgov"
+
+      - name: Publish to GitHub Packages @next
+        run: npm publish --tag next --registry=https://npm.pkg.github.com/
+        working-directory: ./packages/react-components
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish-react-component-library-latest:
     name: Publish @bcgov/design-system-react-components@latest
     # Publish a `latest` version only when a release is published that targets
@@ -104,3 +118,16 @@ jobs:
       - name: Publish to npm @latest
         run: npm publish --tag latest
         working-directory: ./packages/react-components
+
+      - name: Set up Node.js for GitHub Packages
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.GITHUB_NVMRC_VERSION }}
+          registry-url: "https://npm.pkg.github.com/"
+          scope: "@bcgov"
+
+      - name: Publish to GitHub Packages @latest
+        run: npm publish --tag latest --registry=https://npm.pkg.github.com/
+        working-directory: ./packages/react-components
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_react_component_library.yaml
+++ b/.github/workflows/publish_react_component_library.yaml
@@ -1,4 +1,4 @@
-name: Publish @bcgov/design-system-react-components to npm
+name: Publish @bcgov/design-system-react-components to npm and GitHub Packages
 
 on:
   pull_request:

--- a/.github/workflows/publish_react_component_library.yaml
+++ b/.github/workflows/publish_react_component_library.yaml
@@ -10,14 +10,14 @@ on:
     types: [published]
 
 permissions:
-  id-token: write # Required for OIDC
   contents: read
-  packages: write
 
 jobs:
   publish-npm-next:
     # Publish a `next` version to npm on PR merge to `main`
     if: ${{ github.event.pull_request.merged == true && github.repository == 'bcgov/design-system' }}
+    permissions:
+      id-token: write # Required for OIDC
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -61,6 +61,8 @@ jobs:
   publish-github-packages-next:
     # Publish a `next` version to GitHub Packages on PR merge to `main`
     if: ${{ github.event.pull_request.merged == true && github.repository == 'bcgov/design-system' }}
+    permissions:
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -107,6 +109,8 @@ jobs:
   publish-npm-latest:
     # Publish a `latest` version to npm when a release is published that targets `@bcgov/design-system-react-components`
     if: ${{ github.event_name == 'release' && contains(github.event.release.tag_name, 'bcgov/design-system-react-components') }}
+    permissions:
+      id-token: write # Required for OIDC
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -137,6 +141,8 @@ jobs:
   publish-github-packages-latest:
     # Publish a `latest` version to GitHub Packages when a release is published that targets `@bcgov/design-system-react-components`
     if: ${{ github.event_name == 'release' && contains(github.event.release.tag_name, 'bcgov/design-system-react-components') }}
+    permissions:
+      packages: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/publish_react_component_library.yaml
+++ b/.github/workflows/publish_react_component_library.yaml
@@ -76,8 +76,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.GITHUB_NVMRC_VERSION }}
-          registry-url: "https://npm.pkg.github.com/"
-          scope: "@bcgov"
 
       - name: Install dependencies
         run: npm install
@@ -156,8 +154,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.GITHUB_NVMRC_VERSION }}
-          registry-url: "https://npm.pkg.github.com/"
-          scope: "@bcgov"
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
This PR refactors the GHA used to publish new versions of `@bcgov/design-system-react-components` ([publish_react_component_library.yaml](https://github.com/bcgov/design-system/blob/main/.github/workflows/publish_react_component_library.yaml)) to support publishing to both the npm and GitHub Packages registries. 

This workflow now contains 4 jobs:

1. Publish to npm `@next` (trigger on PR merge to `main`)
2. Publish to GitHub `@next` (trigger on PR merge to `main`)
3. Publish to npm `@latest` (trigger on release publish)
4. Publish to GitHub `@latest` (trigger on release publish)

For simplicity, each job is entirely self-contained (rather than attempting to share context via `needs:`) In future we may want to break some duplicated steps into a preliminary `build` job, but leaving that aside for now.

npm jobs authenticate via OIDC with the `--provenance` flag. GitHub Packages jobs authenticate via `packages: write` and `GITHUB_TOKEN`.