### PR TITLE
Add alignment and size props to AlertBanner

### DIFF
--- a/packages/react-components/src/components/AlertBanner/AlertBanner.css
+++ b/packages/react-components/src/components/AlertBanner/AlertBanner.css
@@ -5,7 +5,6 @@
   align-items: center;
   justify-content: space-around;
   width: 100%;
-  padding: var(--layout-padding-none) var(--layout-padding-medium);
 }
 
 .bcds-Alert-Banner--Container {
@@ -14,7 +13,6 @@
   flex-direction: row;
   align-items: center;
   gap: var(--layout-padding-medium);
-  max-width: 1100px;
 }
 
 .bcds-Alert-Banner--Icon {
@@ -31,6 +29,17 @@
   flex-grow: 1;
   flex-wrap: wrap;
   color: var(--typography-color-primary-invert);
+}
+
+/* Alignment */
+.bcds-Alert-Banner.center {
+  padding: var(--layout-padding-none) var(--layout-padding-medium);
+}
+.bcds-Alert-Banner.center > .bcds-Alert-Banner--Container {
+  max-width: 1100px;
+}
+.bcds-Alert-Banner.stretch {
+  padding: var(--layout-padding-none) var(--layout-padding-large);
 }
 
 /* Sizing */

--- a/packages/react-components/src/components/AlertBanner/AlertBanner.css
+++ b/packages/react-components/src/components/AlertBanner/AlertBanner.css
@@ -15,7 +15,6 @@
   align-items: center;
   gap: var(--layout-padding-medium);
   max-width: 1100px;
-  padding: var(--layout-padding-small) var(--layout-padding-none);
 }
 
 .bcds-Alert-Banner--Icon {
@@ -31,10 +30,25 @@
   align-items: first baseline;
   flex-grow: 1;
   flex-wrap: wrap;
-  font: var(--typography-regular-body);
   color: var(--typography-color-primary-invert);
 }
 
+/* Sizing */
+.bcds-Alert-Banner.small > .bcds-Alert-Banner--Container {
+  padding: var(--layout-padding-hair) var(--layout-padding-none);
+}
+.bcds-Alert-Banner.small .bcds-Alert-Banner--Content {
+  font: var(--typography-regular-small-body);
+}
+
+.bcds-Alert-Banner.medium > .bcds-Alert-Banner--Container {
+  padding: var(--layout-padding-small) var(--layout-padding-none);
+}
+.bcds-Alert-Banner.medium .bcds-Alert-Banner--Content {
+  font: var(--typography-regular-body);
+}
+
+/* Close icon */
 .bcds-Alert-Banner--closeIcon {
   align-self: first baseline;
 }

--- a/packages/react-components/src/components/AlertBanner/AlertBanner.css
+++ b/packages/react-components/src/components/AlertBanner/AlertBanner.css
@@ -31,14 +31,14 @@
   color: var(--typography-color-primary-invert);
 }
 
-/* Alignment */
-.bcds-Alert-Banner.center {
+/* Layout */
+.bcds-Alert-Banner.fixed {
   padding: var(--layout-padding-none) var(--layout-padding-medium);
 }
-.bcds-Alert-Banner.center > .bcds-Alert-Banner--Container {
+.bcds-Alert-Banner.fixed > .bcds-Alert-Banner--Container {
   max-width: 1100px;
 }
-.bcds-Alert-Banner.stretch {
+.bcds-Alert-Banner.fluid {
   padding: var(--layout-padding-none) var(--layout-padding-large);
 }
 

--- a/packages/react-components/src/components/AlertBanner/AlertBanner.test.tsx
+++ b/packages/react-components/src/components/AlertBanner/AlertBanner.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import AlertBanner from "./AlertBanner";
+
+describe("AlertBanner", () => {
+  it("renders children content", () => {
+    render(<AlertBanner>Banner content</AlertBanner>);
+
+    expect(screen.getByText(/banner content/i)).toBeInTheDocument();
+  });
+
+  it("applies default classes for variant, size and layout", () => {
+    const { container } = render(<AlertBanner>Default banner</AlertBanner>);
+    const root = container.firstElementChild;
+
+    expect(root).toHaveClass("bcds-Alert-Banner");
+    expect(root).toHaveClass("info");
+    expect(root).toHaveClass("medium");
+    expect(root).toHaveClass("fixed");
+  });
+
+  it("applies provided variant, size and layout classes", () => {
+    const { container } = render(
+      <AlertBanner variant="warning" size="small" layout="fluid">
+        Custom classes
+      </AlertBanner>
+    );
+    const root = container.firstElementChild;
+
+    expect(root).toHaveClass("warning");
+    expect(root).toHaveClass("small");
+    expect(root).toHaveClass("fluid");
+  });
+
+  it("renders close button by default", () => {
+    render(<AlertBanner>Closeable banner</AlertBanner>);
+
+    expect(
+      screen.getByRole("button", { name: /close this alert/i })
+    ).toBeInTheDocument();
+  });
+
+  it("does not render a close button when isCloseable is false", () => {
+    render(<AlertBanner isCloseable={false}>Not closeable banner</AlertBanner>);
+
+    expect(
+      screen.queryByRole("button", { name: /close this alert/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls onClose when close button is pressed", () => {
+    const handleClose = vi.fn();
+    render(<AlertBanner onClose={handleClose}>Close callback</AlertBanner>);
+
+    const closeButton = screen.getByRole("button", {
+      name: /close this alert/i,
+    });
+    fireEvent.click(closeButton);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets role to status by default", () => {
+    render(<AlertBanner>Status role</AlertBanner>);
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("accepts a custom role", () => {
+    render(<AlertBanner role="alert">Alert role</AlertBanner>);
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("renders an icon by default", () => {
+    const { container } = render(<AlertBanner>With icon</AlertBanner>);
+    const iconContainer = container.querySelector(".bcds-Alert-Banner--Icon");
+
+    expect(iconContainer).toBeInTheDocument();
+    expect(iconContainer?.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("does not render the icon when isIconHidden is true", () => {
+    const { container } = render(
+      <AlertBanner isIconHidden>Without icon</AlertBanner>
+    );
+    const iconContainer = container.querySelector(".bcds-Alert-Banner--Icon");
+
+    expect(iconContainer).not.toBeInTheDocument();
+  });
+
+  it("renders customIcon when provided", () => {
+    const customIcon = <span data-testid="custom-icon">*</span>;
+    render(<AlertBanner customIcon={customIcon}>Custom icon</AlertBanner>);
+
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
+  });
+});

--- a/packages/react-components/src/components/AlertBanner/AlertBanner.tsx
+++ b/packages/react-components/src/components/AlertBanner/AlertBanner.tsx
@@ -7,6 +7,8 @@ import SvgExclamationIcon from "../Icons/SvgExclamationIcon";
 import SvgInfoIcon from "../Icons/SvgInfoIcon";
 
 export interface AlertBannerProps extends React.PropsWithChildren {
+  /* Sets vertical height and font size of the banner */
+  size?: "small" | "medium";
   /* Sets banner theme */
   variant?: "info" | "success" | "warning" | "danger" | "black";
   /* Hides icon  */
@@ -41,6 +43,7 @@ function getIcon(variant: string) {
 
 export default function AlertBanner({
   variant = "info",
+  size = "medium",
   isIconHidden = false,
   isCloseable = true,
   role = "status",
@@ -50,7 +53,7 @@ export default function AlertBanner({
   ...props
 }: AlertBannerProps) {
   return (
-    <div className={`bcds-Alert-Banner ${variant}`} {...props}>
+    <div className={`bcds-Alert-Banner ${variant} ${size}`} {...props}>
       <div className="bcds-Alert-Banner--Container">
         {" "}
         {!isIconHidden && (

--- a/packages/react-components/src/components/AlertBanner/AlertBanner.tsx
+++ b/packages/react-components/src/components/AlertBanner/AlertBanner.tsx
@@ -9,6 +9,8 @@ import SvgInfoIcon from "../Icons/SvgInfoIcon";
 export interface AlertBannerProps extends React.PropsWithChildren {
   /* Sets vertical height and font size of the banner */
   size?: "small" | "medium";
+  /* Sets width of the banner */
+  alignment?: "center" | "stretch";
   /* Sets banner theme */
   variant?: "info" | "success" | "warning" | "danger" | "black";
   /* Hides icon  */
@@ -44,6 +46,7 @@ function getIcon(variant: string) {
 export default function AlertBanner({
   variant = "info",
   size = "medium",
+  alignment = "center",
   isIconHidden = false,
   isCloseable = true,
   role = "status",
@@ -53,7 +56,10 @@ export default function AlertBanner({
   ...props
 }: AlertBannerProps) {
   return (
-    <div className={`bcds-Alert-Banner ${variant} ${size}`} {...props}>
+    <div
+      className={`bcds-Alert-Banner ${variant} ${size} ${alignment}`}
+      {...props}
+    >
       <div className="bcds-Alert-Banner--Container">
         {" "}
         {!isIconHidden && (

--- a/packages/react-components/src/components/AlertBanner/AlertBanner.tsx
+++ b/packages/react-components/src/components/AlertBanner/AlertBanner.tsx
@@ -10,7 +10,7 @@ export interface AlertBannerProps extends React.PropsWithChildren {
   /* Sets vertical height and font size of the banner */
   size?: "small" | "medium";
   /* Sets width of the banner */
-  alignment?: "center" | "stretch";
+  layout?: "fixed" | "fluid";
   /* Sets banner theme */
   variant?: "info" | "success" | "warning" | "danger" | "black";
   /* Hides icon  */
@@ -46,7 +46,7 @@ function getIcon(variant: string) {
 export default function AlertBanner({
   variant = "info",
   size = "medium",
-  alignment = "center",
+  layout = "fixed",
   isIconHidden = false,
   isCloseable = true,
   role = "status",
@@ -57,7 +57,7 @@ export default function AlertBanner({
 }: AlertBannerProps) {
   return (
     <div
-      className={`bcds-Alert-Banner ${variant} ${size} ${alignment}`}
+      className={`bcds-Alert-Banner ${variant} ${size} ${layout}`}
       {...props}
     >
       <div className="bcds-Alert-Banner--Container">

--- a/packages/react-components/src/stories/AlertBanner.mdx
+++ b/packages/react-components/src/stories/AlertBanner.mdx
@@ -59,6 +59,12 @@ The `size` prop (defaults to `medium`) controls the vertical height and font siz
 
 <Canvas of={AlertBannerStories.SmallAlertBanner} />
 
+### Alignment
+
+By default, alert banner content is centered. Set `alignment` to `stretch` to make it full-width:
+
+<Canvas of={AlertBannerStories.FullWidthAlertBanner} />
+
 ### Alert content
 
 Pass content to the `children` slot to populate an alert banner.

--- a/packages/react-components/src/stories/AlertBanner.mdx
+++ b/packages/react-components/src/stories/AlertBanner.mdx
@@ -53,6 +53,12 @@ The alert banner ships with a set of themes designed for different use-cases, co
 
 **Note**: if you need to modify the styling of an alert banner's content, you can write additional rules for the `.bcds-Alert-Banner--Container` CSS class.
 
+### Sizing
+
+The `size` prop (defaults to `medium`) controls the vertical height and font size of the banner. Set `size` to `small` for a lower-profile banner:
+
+<Canvas of={AlertBannerStories.SmallAlertBanner} />
+
 ### Alert content
 
 Pass content to the `children` slot to populate an alert banner.

--- a/packages/react-components/src/stories/AlertBanner.mdx
+++ b/packages/react-components/src/stories/AlertBanner.mdx
@@ -61,7 +61,7 @@ The `size` prop (defaults to `medium`) controls the vertical height and font siz
 
 ### Alignment
 
-By default, alert banner content is centered. Set `alignment` to `stretch` to make it full-width:
+By default, alert banner content is centered. Set `layout` to `fluid` to make it full-width:
 
 <Canvas of={AlertBannerStories.FullWidthAlertBanner} />
 

--- a/packages/react-components/src/stories/AlertBanner.stories.tsx
+++ b/packages/react-components/src/stories/AlertBanner.stories.tsx
@@ -22,6 +22,14 @@ const meta = {
         defaultValue: { summary: "medium" },
       },
     },
+    alignment: {
+      options: ["center", "stretch"],
+      control: { type: "radio" },
+      description: "Controls whether banner content is centered or full-width",
+      table: {
+        defaultValue: { summary: "center" },
+      },
+    },
     children: {
       control: { type: "object" },
       description: "Populates the content of the alert",
@@ -68,6 +76,14 @@ export const SmallAlertBanner: Story = {
   ...AlertBannerTemplate,
   args: {
     size: "small",
+    ...AlertBannerTemplate.args,
+  },
+};
+
+export const FullWidthAlertBanner: Story = {
+  ...AlertBannerTemplate,
+  args: {
+    alignment: "stretch",
     ...AlertBannerTemplate.args,
   },
 };

--- a/packages/react-components/src/stories/AlertBanner.stories.tsx
+++ b/packages/react-components/src/stories/AlertBanner.stories.tsx
@@ -14,6 +14,14 @@ const meta = {
       control: { type: "radio" },
       description: "Sets the theme and icon for the alert",
     },
+    size: {
+      options: ["small", "medium"],
+      control: { type: "radio" },
+      description: "Sets the vertical height and font size of the banner",
+      table: {
+        defaultValue: { summary: "medium" },
+      },
+    },
     children: {
       control: { type: "object" },
       description: "Populates the content of the alert",
@@ -54,6 +62,14 @@ export const AlertBannerTemplate: Story = {
     onClose: () => alert("onClose()"),
   },
   render: ({ ...args }: AlertBannerProps) => <AlertBanner {...args} />,
+};
+
+export const SmallAlertBanner: Story = {
+  ...AlertBannerTemplate,
+  args: {
+    size: "small",
+    ...AlertBannerTemplate.args,
+  },
 };
 
 export const SuccessBanner: Story = {

--- a/packages/react-components/src/stories/AlertBanner.stories.tsx
+++ b/packages/react-components/src/stories/AlertBanner.stories.tsx
@@ -22,12 +22,12 @@ const meta = {
         defaultValue: { summary: "medium" },
       },
     },
-    alignment: {
-      options: ["center", "stretch"],
+    layout: {
+      options: ["fixed", "fluid"],
       control: { type: "radio" },
       description: "Controls whether banner content is centered or full-width",
       table: {
-        defaultValue: { summary: "center" },
+        defaultValue: { summary: "fixed" },
       },
     },
     children: {
@@ -83,7 +83,7 @@ export const SmallAlertBanner: Story = {
 export const FullWidthAlertBanner: Story = {
   ...AlertBannerTemplate,
   args: {
-    alignment: "stretch",
+    layout: "fluid",
     ...AlertBannerTemplate.args,
   },
 };


### PR DESCRIPTION
This PR makes two non-breaking changes to `AlertBanner`, responding to insights surfaced by the CMS team:

## Sizing
The `size` prop controls the vertical padding and font size on the banner, to make it more flexible for use in complex/constrained UI. `size` defaults to `medium` (current behaviour), but can also be set to `small`:

<img width="1724" height="148" alt="Screenshot 2026-04-30 at 10 26 34 AM" src="https://github.com/user-attachments/assets/331bc06c-b684-4890-9e91-06dd8659e8be" />

## Alignment
The `alignment` prop controls the horizontal padding and the width of the `children` container. Again, this is designed to make it more flexible. `alignment` defaults to `center` (current behaviour), but can also be set to `stretch`:

<img width="1728" height="162" alt="Screenshot 2026-04-30 at 10 28 18 AM" src="https://github.com/user-attachments/assets/8ce153a9-b9b8-4b3a-b610-d8cbbcd92299" />
