### PR TITLE
Fix Storybook console error and update tests

### DIFF
--- a/packages/react-components/.storybook/vitest.setup.ts
+++ b/packages/react-components/.storybook/vitest.setup.ts
@@ -1,7 +1,24 @@
 import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
 import { setProjectAnnotations } from "@storybook/react-vite";
+import { afterEach, beforeEach, expect, vi } from "vitest";
 import * as projectAnnotations from "./preview";
 
 // This is an important step to apply the right configuration when testing your stories.
 // More info at: https://storybook.js.org/docs/api/portable-stories/portable-stories-vitest#setprojectannotations
 setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+    // Silence warning output during tests; assertions below enforce failure.
+  });
+});
+
+afterEach(() => {
+  try {
+    expect(warnSpy).not.toHaveBeenCalled();
+  } finally {
+    warnSpy.mockRestore();
+  }
+});

--- a/packages/react-components/.storybook/vitest.setup.ts
+++ b/packages/react-components/.storybook/vitest.setup.ts
@@ -1,24 +1,23 @@
 import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
 import { setProjectAnnotations } from "@storybook/react-vite";
-import { afterEach, beforeEach, expect, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, expect, vi } from "vitest";
 import * as projectAnnotations from "./preview";
 
 // This is an important step to apply the right configuration when testing your stories.
 // More info at: https://storybook.js.org/docs/api/portable-stories/portable-stories-vitest#setprojectannotations
 setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);
 
-let warnSpy: ReturnType<typeof vi.spyOn>;
+// Fail tests on console warnings
+const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
 beforeEach(() => {
-  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
-    // Silence warning output during tests; assertions below enforce failure.
-  });
+  expect(warnSpy).not.toHaveBeenCalled();
+  warnSpy.mockClear();
 });
 
 afterEach(() => {
-  try {
-    expect(warnSpy).not.toHaveBeenCalled();
-  } finally {
-    warnSpy.mockRestore();
-  }
+  expect(warnSpy).not.toHaveBeenCalled();
+});
+afterAll(() => {
+  warnSpy.mockRestore();
 });

--- a/packages/react-components/src/stories/NumberField.stories.tsx
+++ b/packages/react-components/src/stories/NumberField.stories.tsx
@@ -225,6 +225,7 @@ export const DistanceUnits: Story = {
           ]}
           defaultValue="kilometer"
           value={unit}
+          aria-label="Distance units"
           onChange={(v: Key | null) => {
             if (typeof v === "string") {
               setUnit(v);

--- a/packages/react-components/src/vitest.unit.setup.ts
+++ b/packages/react-components/src/vitest.unit.setup.ts
@@ -1,0 +1,17 @@
+import { afterEach, beforeEach, expect, vi } from "vitest";
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+    // Silence warning output during tests; assertions below enforce failure.
+  });
+});
+
+afterEach(() => {
+  try {
+    expect(warnSpy).not.toHaveBeenCalled();
+  } finally {
+    warnSpy.mockRestore();
+  }
+});

--- a/packages/react-components/src/vitest.unit.setup.ts
+++ b/packages/react-components/src/vitest.unit.setup.ts
@@ -1,17 +1,15 @@
-import { afterEach, beforeEach, expect, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, expect, vi } from "vitest";
 
-let warnSpy: ReturnType<typeof vi.spyOn>;
+// Fail tests on console warnings
+const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
 beforeEach(() => {
-  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
-    // Silence warning output during tests; assertions below enforce failure.
-  });
+  warnSpy.mockClear();
 });
 
 afterEach(() => {
-  try {
-    expect(warnSpy).not.toHaveBeenCalled();
-  } finally {
-    warnSpy.mockRestore();
-  }
+  expect(warnSpy).not.toHaveBeenCalled();
+});
+afterAll(() => {
+  warnSpy.mockRestore();
 });

--- a/packages/react-components/vite.config.ts
+++ b/packages/react-components/vite.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
           name: "unit",
           globals: true,
           environment: "jsdom",
+          setupFiles: ["./src/vitest.unit.setup.ts"],
           include: ["./src/components/**/*.test.{ts,tsx,js,jsx}"],
         },
       },


### PR DESCRIPTION
This PR resolves the issues identified in #658. It adds a missing `aria-label` to one of the NumberField examples. It also adds some new Vitest config that will cause both the unit test and Storybook test suites to fail on `console.warn()`. 

Without the fix in d1ca4a95eef881b7fd01ca8acbfd9d2837203758:
 
<img width="827" height="282" alt="Screenshot 2026-04-30 at 1 50 59 PM" src="https://github.com/user-attachments/assets/e8ac6b9b-0ce1-4e5e-b82c-ba1cdc095a1e" />

With the fix in place, all tests pass as expected.