### PR TITLE
Update components publish workflow

### DIFF
--- a/.github/workflows/publish_react_component_library.yaml
+++ b/.github/workflows/publish_react_component_library.yaml
@@ -9,14 +9,12 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: read
-
 jobs:
   publish-npm-next:
     # Publish a `next` version to npm on PR merge to `main`
     if: ${{ github.event.pull_request.merged == true && github.repository == 'bcgov/design-system' }}
     permissions:
+      contents: read
       id-token: write # Required for OIDC
     runs-on: ubuntu-latest
     steps:
@@ -62,6 +60,7 @@ jobs:
     # Publish a `next` version to GitHub Packages on PR merge to `main`
     if: ${{ github.event.pull_request.merged == true && github.repository == 'bcgov/design-system' }}
     permissions:
+      contents: read
       packages: write
     runs-on: ubuntu-latest
     steps:
@@ -108,6 +107,7 @@ jobs:
     # Publish a `latest` version to npm when a release is published that targets `@bcgov/design-system-react-components`
     if: ${{ github.event_name == 'release' && contains(github.event.release.tag_name, 'bcgov/design-system-react-components') }}
     permissions:
+      contents: read
       id-token: write # Required for OIDC
     runs-on: ubuntu-latest
     steps:
@@ -140,6 +140,7 @@ jobs:
     # Publish a `latest` version to GitHub Packages when a release is published that targets `@bcgov/design-system-react-components`
     if: ${{ github.event_name == 'release' && contains(github.event.release.tag_name, 'bcgov/design-system-react-components') }}
     permissions:
+      contents: read
       packages: write
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish_react_component_library.yaml
+++ b/.github/workflows/publish_react_component_library.yaml
@@ -32,7 +32,7 @@ jobs:
           registry-url: "https://registry.npmjs.org/"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
         working-directory: ./packages/react-components
 
       - name: Install jq
@@ -77,7 +77,7 @@ jobs:
           node-version: ${{ env.GITHUB_NVMRC_VERSION }}
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
         working-directory: ./packages/react-components
 
       - name: Install jq
@@ -125,7 +125,7 @@ jobs:
           registry-url: "https://registry.npmjs.org/"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
         working-directory: ./packages/react-components
 
       - name: Build components for publishing
@@ -157,7 +157,7 @@ jobs:
           node-version: ${{ env.GITHUB_NVMRC_VERSION }}
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
         working-directory: ./packages/react-components
 
       - name: Build components for publishing

--- a/.github/workflows/publish_react_component_library.yaml
+++ b/.github/workflows/publish_react_component_library.yaml
@@ -32,7 +32,7 @@ jobs:
           registry-url: "https://registry.npmjs.org/"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
         working-directory: ./packages/react-components
 
       - name: Install jq
@@ -77,7 +77,7 @@ jobs:
           node-version: ${{ env.GITHUB_NVMRC_VERSION }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
         working-directory: ./packages/react-components
 
       - name: Install jq
@@ -125,7 +125,7 @@ jobs:
           registry-url: "https://registry.npmjs.org/"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
         working-directory: ./packages/react-components
 
       - name: Build components for publishing
@@ -157,7 +157,7 @@ jobs:
           node-version: ${{ env.GITHUB_NVMRC_VERSION }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
         working-directory: ./packages/react-components
 
       - name: Build components for publishing


### PR DESCRIPTION
This PR pre-emptively corrects an anticipated issue with the changes to the `@bcgov/design-system-react-components` workflow from #677:

Previously, permissions were set in two places:

- `contents: read` at workflow level
- `id-token: write` (for npm) and `packages: write` (for GitHub Packages) at job level

This change moves the `contents: read` permission to each individual job (because it appears that the job-level permissions block [overwrites, rather than inherits](https://www.kenmuse.com/blog/github-actions-workflow-permissions/) the workflow-level permissions.)