### PR TITLE
Update design tokens publish workflow

### DIFF
--- a/.github/workflows/publish_design_tokens.yaml
+++ b/.github/workflows/publish_design_tokens.yaml
@@ -69,7 +69,7 @@ jobs:
         working-directory: ./packages/design-tokens/dist
 
       - name: Publish to npm @next
-        run: npm publish --tag next
+        run: npm publish --tag next --provenance
         working-directory: ./packages/design-tokens/dist
 
   publish-design-tokens-github-packages-next:
@@ -129,9 +129,11 @@ jobs:
         shell: bash
         working-directory: ./packages/design-tokens/dist
 
-      - name: Publish to npm @next
+      - name: Publish to GitHub Packages @next
         run: npm publish --tag next --registry=https://npm.pkg.github.com/
         working-directory: ./packages/design-tokens/dist
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-design-tokens-npm-latest:
     name: Publish @bcgov/design-tokens@latest to npm
@@ -171,7 +173,7 @@ jobs:
         working-directory: ./packages/design-tokens
 
       - name: Publish to npm @latest
-        run: npm publish --tag latest
+        run: npm publish --tag latest --provenance
         working-directory: ./packages/design-tokens/dist
 
   publish-design-tokens-github-packages-latest:
@@ -213,3 +215,5 @@ jobs:
       - name: Publish to GitHub Packages @latest
         run: npm publish --tag latest --registry=https://npm.pkg.github.com/
         working-directory: ./packages/design-tokens/dist
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_design_tokens.yaml
+++ b/.github/workflows/publish_design_tokens.yaml
@@ -105,6 +105,14 @@ jobs:
         run: npm run build
         working-directory: ./packages/design-tokens
 
+      # After dependencies are installed and build is complete, change registry to GitHub Packages
+      - name: Rerun Node.js setup for GitHub Packages publishing
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.GITHUB_NVMRC_VERSION }}
+          registry-url: "https://npm.pkg.github.com/"
+          scope: "@bcgov"
+
       - name: Prepare npm package for publishing
         run: npm run prepare-npm-package
         working-directory: ./packages/design-tokens
@@ -211,6 +219,14 @@ jobs:
       - name: Prepare npm package for publishing
         run: npm run prepare-npm-package
         working-directory: ./packages/design-tokens
+
+      # After dependencies are installed and build is complete, change registry to GitHub Packages
+      - name: Rerun Node.js setup for GitHub Packages publishing
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.GITHUB_NVMRC_VERSION }}
+          registry-url: "https://npm.pkg.github.com/"
+          scope: "@bcgov"
 
       - name: Publish to GitHub Packages @latest
         run: npm publish --tag latest --registry=https://npm.pkg.github.com/

--- a/.github/workflows/publish_design_tokens.yaml
+++ b/.github/workflows/publish_design_tokens.yaml
@@ -1,4 +1,4 @@
-name: Publish @bcgov/design-tokens to npm
+name: Publish @bcgov/design-tokens to npm and GitHub Packages
 
 on:
   pull_request:
@@ -10,14 +10,15 @@ on:
     types: [published]
 
 permissions:
-  id-token: write # Required for OIDC
   contents: read
 
 jobs:
-  publish-design-tokens-next:
-    name: Publish @bcgov/design-tokens@next
-    # Publish a `next` version on PR merge to main branch.
+  publish-design-tokens-npm-next:
+    name: Publish @bcgov/design-tokens@next to npm
+    # Publish a `next` version to npm on PR merge to main branch.
     if: ${{ github.event.pull_request.merged == true && github.repository == 'bcgov/design-system' }}
+    permissions:
+      id-token: write # Required for OIDC
     runs-on: ubuntu-latest
 
     steps:
@@ -73,12 +74,74 @@ jobs:
         run: npm publish --tag next
         working-directory: ./packages/design-tokens/dist
 
-  publish-design-tokens-latest:
-    name: Publish @bcgov/design-tokens@latest
-    # Publish a `latest` version only when a release is published that targets
+  publish-design-tokens-github-packages-next:
+    name: Publish @bcgov/design-tokens@next to GitHub Packages
+    # Publish a `next` version to GitHub Packages on PR merge to main branch.
+    if: ${{ github.event.pull_request.merged == true && github.repository == 'bcgov/design-system' }}
+    permissions:
+      packages: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Read .nvmrc
+        run: echo "GITHUB_NVMRC_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV
+        working-directory: ./packages/design-tokens
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.GITHUB_NVMRC_VERSION }}
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: ./packages/design-tokens
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Run build script
+        run: npm run build
+        working-directory: ./packages/design-tokens
+
+      - name: Prepare npm package for publishing
+        run: npm run prepare-npm-package
+        working-directory: ./packages/design-tokens
+
+      # Use `jq` to change the package.json version to look like:
+      #
+      #   <version in package.json>-pr<PR # that caused the workflow run>
+      #
+      # So package.json version v1.2.3 with a run caused by merging PR #456 to
+      # `main` causes the version of the package on npm to look like:
+      #
+      #   1.2.3-pr456
+      #
+      # This is to ensure that it's easy to map an npm version to a particular PR.
+      #
+      - name: Update version in dist/package.json
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          CURRENT_VERSION=$(jq -r '.version' package.json)
+          NEW_VERSION="${CURRENT_VERSION}-pr${PR_NUMBER}"
+          jq --arg new_version "$NEW_VERSION" '.version = $new_version' package.json > tmp.json && mv tmp.json package.json
+        shell: bash
+        working-directory: ./packages/design-tokens/dist
+
+      - name: Publish to npm @next
+        run: npm publish --tag next --registry=https://npm.pkg.github.com/
+        working-directory: ./packages/design-tokens/dist
+
+  publish-design-tokens-npm-latest:
+    name: Publish @bcgov/design-tokens@latest to npm
+    # Publish a `latest` version to npm only when a release is published that targets
     # the design tokens package via a tag like:
     # @bcgov/design-tokens@v1.2.3
     if: ${{ github.event_name == 'release' && contains(github.event.release.tag_name, 'bcgov/design-tokens') }}
+    permissions:
+      id-token: write # Required for OIDC
     runs-on: ubuntu-latest
 
     steps:
@@ -109,4 +172,43 @@ jobs:
 
       - name: Publish to npm @latest
         run: npm publish --tag latest
+        working-directory: ./packages/design-tokens/dist
+
+  publish-design-tokens-github-packages-latest:
+    name: Publish @bcgov/design-tokens@latest to GitHub Packages
+    # Publish a `latest` version to GitHub Packages only when a release is published that targets
+    # the design tokens package via a tag like:
+    # @bcgov/design-tokens@v1.2.3
+    if: ${{ github.event_name == 'release' && contains(github.event.release.tag_name, 'bcgov/design-tokens') }}
+    permissions:
+      packages: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Read .nvmrc
+        run: echo "GITHUB_NVMRC_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV
+        working-directory: ./packages/design-tokens
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.GITHUB_NVMRC_VERSION }}
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: ./packages/design-tokens
+
+      - name: Run build script
+        run: npm run build
+        working-directory: ./packages/design-tokens
+
+      - name: Prepare npm package for publishing
+        run: npm run prepare-npm-package
+        working-directory: ./packages/design-tokens
+
+      - name: Publish to GitHub Packages @latest
+        run: npm publish --tag latest --registry=https://npm.pkg.github.com/
         working-directory: ./packages/design-tokens/dist

--- a/.github/workflows/publish_design_tokens.yaml
+++ b/.github/workflows/publish_design_tokens.yaml
@@ -9,15 +9,13 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: read
-
 jobs:
   publish-design-tokens-npm-next:
     name: Publish @bcgov/design-tokens@next to npm
     # Publish a `next` version to npm on PR merge to main branch.
     if: ${{ github.event.pull_request.merged == true && github.repository == 'bcgov/design-system' }}
     permissions:
+      contents: read
       id-token: write # Required for OIDC
     runs-on: ubuntu-latest
 
@@ -79,6 +77,7 @@ jobs:
     # Publish a `next` version to GitHub Packages on PR merge to main branch.
     if: ${{ github.event.pull_request.merged == true && github.repository == 'bcgov/design-system' }}
     permissions:
+      contents: read
       packages: write
     runs-on: ubuntu-latest
 
@@ -141,6 +140,7 @@ jobs:
     # @bcgov/design-tokens@v1.2.3
     if: ${{ github.event_name == 'release' && contains(github.event.release.tag_name, 'bcgov/design-tokens') }}
     permissions:
+      contents: read
       id-token: write # Required for OIDC
     runs-on: ubuntu-latest
 
@@ -181,6 +181,7 @@ jobs:
     # @bcgov/design-tokens@v1.2.3
     if: ${{ github.event_name == 'release' && contains(github.event.release.tag_name, 'bcgov/design-tokens') }}
     permissions:
+      contents: read
       packages: write
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This PR updates the publish workflow for `@bcgov/design-tokens` to match the new pattern from #677 (cross-publishing to both npm and GitHub Packages.) It also includes the permissions structure change from #681.

**Note**: hold on merging this change until we have tested that the new workflow structure works as intended.