### PR TITLE
Add Menu, MenuItem and MenuTrigger components

### DIFF
--- a/packages/react-components/src/App.tsx
+++ b/packages/react-components/src/App.tsx
@@ -1,9 +1,15 @@
-import { Menu, MenuItem, MenuTrigger, Popover } from "react-aria-components";
-
 import "./App.css";
 import "@bcgov/bc-sans/css/BC_Sans.css";
 
-import { Button, Footer, FooterLinks, Header } from "@/components";
+import {
+  Button,
+  Footer,
+  FooterLinks,
+  Header,
+  Menu,
+  MenuItem,
+  MenuTrigger,
+} from "@/components";
 import useWindowDimensions from "@/hooks/useWindowDimensions";
 import {
   AccordionGroupPage,
@@ -95,13 +101,11 @@ function App() {
               <Button size="small" variant="secondary">
                 Menu <SvgMenuIcon />
               </Button>
-              <Popover>
-                <Menu>
-                  <MenuItem className="menu-item">Link</MenuItem>
-                  <MenuItem className="menu-item">Link</MenuItem>
-                  <MenuItem className="menu-item">Link</MenuItem>
-                </Menu>
-              </Popover>
+              <Menu>
+                <MenuItem>Link</MenuItem>
+                <MenuItem>Link</MenuItem>
+                <MenuItem>Link</MenuItem>
+              </Menu>
             </MenuTrigger>
           )}
         </div>

--- a/packages/react-components/src/App.tsx
+++ b/packages/react-components/src/App.tsx
@@ -101,7 +101,7 @@ function App() {
               <Button size="small" variant="secondary">
                 Menu <SvgMenuIcon />
               </Button>
-              <Menu>
+              <Menu aria-label="Menu">
                 <MenuItem>Link</MenuItem>
                 <MenuItem>Link</MenuItem>
                 <MenuItem>Link</MenuItem>

--- a/packages/react-components/src/components/Menu/Menu.css
+++ b/packages/react-components/src/components/Menu/Menu.css
@@ -43,3 +43,4 @@
   padding: var(--layout-padding-xsmall) var(--layout-padding-xsmall);
   min-width: var(--trigger-width);
   overflow-y: auto;
+}

--- a/packages/react-components/src/components/Menu/Menu.css
+++ b/packages/react-components/src/components/Menu/Menu.css
@@ -1,7 +1,8 @@
 .bcds-react-aria-Menu {
-  display: flex;
-  flex-direction: column;
-  padding: var(--layout-padding-none);
+  overflow-y: auto;
+  max-height: inherit;
+  scroll-padding-block: var(--layout-border-width-medium);
+  padding: var(--layout-padding-hair) var(--layout-padding-none);
 }
 
 /* Sizing */
@@ -28,9 +29,6 @@
 .bcds-react-aria-Menu[data-focused] {
   outline: none;
 }
-.bcds-react-aria-Popover:focus {
-  outline: none;
-}
 
 /* Popover */
 .bcds-react-aria-Popover {
@@ -40,7 +38,9 @@
   border-radius: var(--layout-border-radius-medium);
   box-shadow: var(--surface-shadow-medium);
   box-sizing: border-box;
-  padding: var(--layout-padding-xsmall) var(--layout-padding-xsmall);
-  min-width: var(--trigger-width);
-  overflow-y: auto;
+  overflow: hidden;
+  padding: var(--layout-padding-hair) var(--layout-padding-xsmall);
+  width: var(
+    --trigger-width
+  ); /* Variable provided by Select component https://react-spectrum.adobe.com/react-aria/Select.html#popover-1 */
 }

--- a/packages/react-components/src/components/Menu/Menu.css
+++ b/packages/react-components/src/components/Menu/Menu.css
@@ -1,0 +1,46 @@
+.bcds-react-aria-Menu {
+  display: flex;
+  flex-direction: column;
+  padding: var(--layout-padding-none);
+}
+
+/* Sizing */
+.bcds-react-aria-Menu.small {
+  font: var(--typography-regular-small-body);
+}
+
+.bcds-react-aria-Menu.medium {
+  font: var(--typography-regular-body);
+}
+
+/* Sections */
+.bcds-react-aria-Menu .react-aria-Header {
+  padding: var(--layout-padding-small);
+  font: var(--typography-bold-small-body);
+}
+.bcds-react-aria-Menu .react-aria-MenuSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--layout-margin-small);
+}
+
+/* States */
+.bcds-react-aria-Menu[data-focused] {
+  outline: none;
+}
+.bcds-react-aria-Popover:focus {
+  outline: none;
+}
+
+/* Popover */
+.bcds-react-aria-Popover {
+  background-color: var(--surface-color-forms-default);
+  border: var(--layout-border-width-small) solid
+    var(--surface-color-border-default);
+  border-radius: var(--layout-border-radius-medium);
+  box-shadow: var(--surface-shadow-medium);
+  box-sizing: border-box;
+  padding: var(--layout-padding-xsmall) var(--layout-padding-xsmall);
+  min-width: var(--trigger-width);
+  overflow-y: scroll;
+}

--- a/packages/react-components/src/components/Menu/Menu.css
+++ b/packages/react-components/src/components/Menu/Menu.css
@@ -1,8 +1,8 @@
 .bcds-react-aria-Menu {
+  box-sizing: border-box;
   overflow-y: auto;
   max-height: inherit;
-  scroll-padding-block: var(--layout-border-width-medium);
-  padding: var(--layout-padding-hair) var(--layout-padding-none);
+  padding: var(--layout-padding-xsmall);
 }
 
 /* Sizing */
@@ -39,7 +39,6 @@
   box-shadow: var(--surface-shadow-medium);
   box-sizing: border-box;
   overflow: hidden;
-  padding: var(--layout-padding-hair) var(--layout-padding-xsmall);
   min-width: var(
     --trigger-width
   ); /* Variable provided by Select component https://react-spectrum.adobe.com/react-aria/Select.html#popover-1 */

--- a/packages/react-components/src/components/Menu/Menu.css
+++ b/packages/react-components/src/components/Menu/Menu.css
@@ -42,5 +42,4 @@
   box-sizing: border-box;
   padding: var(--layout-padding-xsmall) var(--layout-padding-xsmall);
   min-width: var(--trigger-width);
-  overflow-y: scroll;
-}
+  overflow-y: auto;

--- a/packages/react-components/src/components/Menu/Menu.css
+++ b/packages/react-components/src/components/Menu/Menu.css
@@ -40,7 +40,7 @@
   box-sizing: border-box;
   overflow: hidden;
   padding: var(--layout-padding-hair) var(--layout-padding-xsmall);
-  width: var(
+  min-width: var(
     --trigger-width
   ); /* Variable provided by Select component https://react-spectrum.adobe.com/react-aria/Select.html#popover-1 */
 }

--- a/packages/react-components/src/components/Menu/Menu.test.tsx
+++ b/packages/react-components/src/components/Menu/Menu.test.tsx
@@ -33,7 +33,7 @@ describe("Menu", () => {
     render(
       <MenuTrigger>
         <Button>Open</Button>
-        <Menu aria-label="Actions" size="small">
+        <Menu aria-label="Actions" itemSize="small">
           <MenuItem id="edit">Edit</MenuItem>
         </Menu>
       </MenuTrigger>

--- a/packages/react-components/src/components/Menu/Menu.test.tsx
+++ b/packages/react-components/src/components/Menu/Menu.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import Menu, { MenuSectionProps, MenuTrigger } from "./Menu";
+import MenuItem from "../MenuItem";
+import Button from "../Button";
+
+describe("Menu", () => {
+  it("renders menu items from children when opened", async () => {
+    render(
+      <MenuTrigger>
+        <Button>Open</Button>
+        <Menu aria-label="Actions">
+          <MenuItem id="edit">Edit</MenuItem>
+          <MenuItem id="delete">Delete</MenuItem>
+        </Menu>
+      </MenuTrigger>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /open/i }));
+
+    expect(await screen.findByRole("menu")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("menuitem", { name: /edit/i })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("menuitem", { name: /delete/i })
+    ).toBeInTheDocument();
+  });
+
+  it("applies the size class", async () => {
+    render(
+      <MenuTrigger>
+        <Button>Open</Button>
+        <Menu aria-label="Actions" size="small">
+          <MenuItem id="edit">Edit</MenuItem>
+        </Menu>
+      </MenuTrigger>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /open/i }));
+
+    expect(await screen.findByRole("menu")).toHaveClass(
+      "bcds-react-aria-Menu small"
+    );
+  });
+
+  it("renders section headers and separator between sections", async () => {
+    const sections: MenuSectionProps[] = [
+      {
+        id: "file",
+        header: "File",
+        items: [{ id: "new", children: "New" }],
+      },
+      {
+        id: "edit",
+        header: "Edit",
+        items: [{ id: "copy", children: "Copy" }],
+      },
+    ];
+
+    render(
+      <MenuTrigger>
+        <Button>Open</Button>
+        <Menu aria-label="Sectioned actions" sections={sections} />
+      </MenuTrigger>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /open/i }));
+
+    expect(await screen.findByText("File")).toBeInTheDocument();
+    expect(await screen.findByText("Edit")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("menuitem", { name: /new/i })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("menuitem", { name: /copy/i })
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("separator")).toHaveLength(1);
+  });
+});

--- a/packages/react-components/src/components/Menu/Menu.tsx
+++ b/packages/react-components/src/components/Menu/Menu.tsx
@@ -1,0 +1,100 @@
+import {
+  MenuTrigger,
+  Menu as ReactAriaMenu,
+  MenuProps as ReactAriaMenuProps,
+  MenuSection,
+  Header as MenuSectionHeader,
+  SubmenuTrigger,
+  Popover,
+  PopoverProps,
+  Key,
+  Collection,
+} from "react-aria-components";
+
+import MenuItem, { MenuItemProps } from "../MenuItem/MenuItem";
+import Separator from "../Separator";
+
+import "./Menu.css";
+
+export interface MenuSectionProps {
+  /* Unique identifier for the section */
+  id: Key;
+  /* Text label for the section */
+  header?: string;
+  /* Array of items in the section */
+  items: MenuItemProps[];
+}
+
+export interface MenuProps<
+  T extends MenuItemProps,
+> extends ReactAriaMenuProps<T> {
+  /* Set size of menu button and items */
+  size?: "small" | "medium";
+  /* Use for a simple list menu */
+  items?: T[];
+  /* Use for a sectioned list with `items` in each section */
+  sections?: MenuSectionProps[];
+  /* Popover position */
+  placement?: PopoverProps["placement"];
+}
+
+export default function Menu<T extends MenuItemProps>({
+  size = "medium",
+  children,
+  items,
+  sections,
+  placement,
+  ...props
+}: MenuProps<T>) {
+  /* Manual composition via children */
+  if (children) {
+    return (
+      <Popover className="bcds-react-aria-Popover" placement={placement}>
+        <ReactAriaMenu
+          className={`bcds-react-aria-Menu ${size}`}
+          items={items}
+          {...props}
+        >
+          {children}
+        </ReactAriaMenu>
+      </Popover>
+    );
+  }
+  /* Dynamic collection via items/sections props */
+  const sectionsArray = sections?.length
+    ? sections
+    : [{ id: "section", header: "", items: items ? [...items] : [] }];
+
+  const lastSectionId =
+    sectionsArray.length > 0
+      ? sectionsArray[sectionsArray.length - 1].id
+      : undefined;
+
+  return (
+    <Popover className="bcds-react-aria-Popover" placement={placement}>
+      <ReactAriaMenu
+        className={`bcds-react-aria-Menu ${size}`}
+        {...props}
+        items={sectionsArray}
+      >
+        {(section: MenuSectionProps) => (
+          <MenuSection key={section.id} id={section.id}>
+            {section.header && (
+              <MenuSectionHeader>{section.header}</MenuSectionHeader>
+            )}
+            <Collection items={section.items}>
+              {(item: MenuItemProps) => (
+                <MenuItem {...item} size={size}>
+                  {item.children}
+                </MenuItem>
+              )}
+            </Collection>
+            {section.id !== lastSectionId && <Separator size="small" />}
+          </MenuSection>
+        )}
+      </ReactAriaMenu>
+    </Popover>
+  );
+}
+
+export { MenuTrigger, SubmenuTrigger, MenuSection, MenuSectionHeader };

--- a/packages/react-components/src/components/Menu/Menu.tsx
+++ b/packages/react-components/src/components/Menu/Menu.tsx
@@ -30,7 +30,7 @@ export interface MenuProps<
   T extends MenuItemProps,
 > extends ReactAriaMenuProps<T> {
   /* Set size of menu items (does not affect the MenuTrigger element) */
-  size?: "small" | "medium";
+  itemSize?: "small" | "medium";
   /* Use for a simple list menu */
   items?: T[];
   /* Use for a sectioned list with `items` in each section */
@@ -40,7 +40,7 @@ export interface MenuProps<
 }
 
 export default function Menu<T extends MenuItemProps>({
-  size = "medium",
+  itemSize = "medium",
   children,
   items,
   sections,
@@ -59,7 +59,7 @@ export default function Menu<T extends MenuItemProps>({
       >
         <ReactAriaMenu
           ref={menuScrollRef}
-          className={`bcds-react-aria-Menu ${size}`}
+          className={`bcds-react-aria-Menu ${itemSize}`}
           items={items}
           {...props}
         >
@@ -86,7 +86,7 @@ export default function Menu<T extends MenuItemProps>({
     >
       <ReactAriaMenu
         ref={menuScrollRef}
-        className={`bcds-react-aria-Menu ${size}`}
+        className={`bcds-react-aria-Menu ${itemSize}`}
         {...props}
         items={sectionsArray}
       >
@@ -97,7 +97,7 @@ export default function Menu<T extends MenuItemProps>({
             )}
             <Collection items={section.items}>
               {(item: MenuItemProps) => (
-                <MenuItem {...item} size={size}>
+                <MenuItem {...item} size={itemSize}>
                   {item.children}
                 </MenuItem>
               )}

--- a/packages/react-components/src/components/Menu/Menu.tsx
+++ b/packages/react-components/src/components/Menu/Menu.tsx
@@ -10,6 +10,7 @@ import {
   Key,
   Collection,
 } from "react-aria-components";
+import { useRef } from "react";
 
 import MenuItem, { MenuItemProps } from "../MenuItem/MenuItem";
 import Separator from "../Separator";
@@ -46,11 +47,18 @@ export default function Menu<T extends MenuItemProps>({
   placement,
   ...props
 }: MenuProps<T>) {
+  const menuScrollRef = useRef<HTMLDivElement | null>(null);
+
   /* Manual composition via children */
   if (children) {
     return (
-      <Popover className="bcds-react-aria-Popover" placement={placement}>
+      <Popover
+        className="bcds-react-aria-Popover"
+        placement={placement}
+        scrollRef={menuScrollRef}
+      >
         <ReactAriaMenu
+          ref={menuScrollRef}
           className={`bcds-react-aria-Menu ${size}`}
           items={items}
           {...props}
@@ -71,8 +79,13 @@ export default function Menu<T extends MenuItemProps>({
       : undefined;
 
   return (
-    <Popover className="bcds-react-aria-Popover" placement={placement}>
+    <Popover
+      className="bcds-react-aria-Popover"
+      placement={placement}
+      scrollRef={menuScrollRef}
+    >
       <ReactAriaMenu
+        ref={menuScrollRef}
         className={`bcds-react-aria-Menu ${size}`}
         {...props}
         items={sectionsArray}

--- a/packages/react-components/src/components/Menu/Menu.tsx
+++ b/packages/react-components/src/components/Menu/Menu.tsx
@@ -10,7 +10,6 @@ import {
   Key,
   Collection,
 } from "react-aria-components";
-import { useRef } from "react";
 
 import MenuItem, { MenuItemProps } from "../MenuItem/MenuItem";
 import Separator from "../Separator";
@@ -47,18 +46,11 @@ export default function Menu<T extends MenuItemProps>({
   placement,
   ...props
 }: MenuProps<T>) {
-  const menuScrollRef = useRef<HTMLDivElement | null>(null);
-
   /* Manual composition via children */
   if (children) {
     return (
-      <Popover
-        className="bcds-react-aria-Popover"
-        placement={placement}
-        scrollRef={menuScrollRef}
-      >
+      <Popover className="bcds-react-aria-Popover" placement={placement}>
         <ReactAriaMenu
-          ref={menuScrollRef}
           className={`bcds-react-aria-Menu ${itemSize}`}
           items={items}
           {...props}
@@ -79,13 +71,8 @@ export default function Menu<T extends MenuItemProps>({
       : undefined;
 
   return (
-    <Popover
-      className="bcds-react-aria-Popover"
-      placement={placement}
-      scrollRef={menuScrollRef}
-    >
+    <Popover className="bcds-react-aria-Popover" placement={placement}>
       <ReactAriaMenu
-        ref={menuScrollRef}
         className={`bcds-react-aria-Menu ${itemSize}`}
         {...props}
         items={sectionsArray}

--- a/packages/react-components/src/components/Menu/Menu.tsx
+++ b/packages/react-components/src/components/Menu/Menu.tsx
@@ -28,7 +28,7 @@ export interface MenuSectionProps {
 export interface MenuProps<
   T extends MenuItemProps,
 > extends ReactAriaMenuProps<T> {
-  /* Set size of menu button and items */
+  /* Set size of menu items (does not affect the MenuTrigger element) */
   size?: "small" | "medium";
   /* Use for a simple list menu */
   items?: T[];

--- a/packages/react-components/src/components/Menu/index.ts
+++ b/packages/react-components/src/components/Menu/index.ts
@@ -1,0 +1,9 @@
+export {
+  default,
+  MenuTrigger,
+  SubmenuTrigger,
+  MenuSection,
+  MenuSectionHeader,
+} from "./Menu";
+
+export type { MenuProps, MenuSectionProps } from "./Menu";

--- a/packages/react-components/src/components/MenuItem/MenuItem.css
+++ b/packages/react-components/src/components/MenuItem/MenuItem.css
@@ -1,0 +1,91 @@
+.bcds-react-aria-MenuItem {
+  display: flex;
+  gap: var(--layout-margin-xsmall);
+  padding: var(--layout-padding-small);
+  cursor: pointer;
+  color: var(--typography-color-secondary);
+}
+.bcds-react-aria-MenuItem--Icon {
+  display: flex;
+  align-self: flex-start;
+  padding-top: var(--layout-padding-xsmall);
+}
+.bcds-react-aria-MenuItem--Content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--layout-padding-hair);
+}
+
+/* Sizing */
+.bcds-react-aria-MenuItem.small {
+  font: var(--typography-regular-small-body);
+}
+.bcds-react-aria-MenuItem.small
+  > .bcds-react-aria-MenuItem--Content
+  > *[slot="description"] {
+  font: var(--typography-regular-label);
+}
+.bcds-react-aria-MenuItem.medium {
+  font: var(--typography-regular-body);
+}
+.bcds-react-aria-MenuItem.medium
+  > .bcds-react-aria-MenuItem--Content
+  > *[slot="description"] {
+  font: var(--typography-regular-small-body);
+}
+
+/* Link styling */
+a.bcds-react-aria-MenuItem {
+  text-decoration: none;
+}
+a.bcds-react-aria-MenuItem
+  > .bcds-react-aria-MenuItem--Content
+  > *[slot="label"] {
+  color: var(--typography-color-link);
+  text-decoration: underline var(--typography-color-link);
+  text-underline-offset: var(--layout-margin-hair);
+}
+a.bcds-react-aria-MenuItem
+  > .bcds-react-aria-MenuItem--Content
+  > *[slot="description"] {
+  color: var(--typography-color-secondary);
+  text-decoration: none;
+}
+a.bcds-react-aria-MenuItem[data-disabled]
+  > .bcds-react-aria-MenuItem--Content
+  > *[slot="label"] {
+  color: var(--typography-color-disabled);
+  text-decoration: none;
+}
+a.bcds-react-aria-MenuItem[data-disabled]
+  > .bcds-react-aria-MenuItem--Content
+  > *[slot="description"] {
+  color: var(--typography-color-disabled);
+}
+
+/* Icon displayed when an item has a submenu */
+.bcds-react-aria-MenuItem > svg {
+  width: var(--icons-size-xsmall);
+  height: var(--icons-size-xsmall);
+  padding: var(--layout-padding-hair);
+  align-self: center;
+}
+
+/* States */
+.bcds-react-aria-MenuItem[data-focused],
+.bcds-react-aria-MenuItem[data-hovered],
+.bcds-react-aria-MenuItem[data-hovered][data-focused] {
+  border-radius: var(--layout-border-radius-small);
+  background-color: var(--surface-color-menus-hover);
+  outline: none;
+}
+.bcds-react-aria-MenuItem[data-focus-visible] {
+  outline: solid var(--layout-border-width-medium)
+    var(--surface-color-border-active);
+  outline-offset: var(--layout-margin-none);
+  border-radius: var(--layout-border-radius-small);
+}
+.bcds-react-aria-MenuItem[data-disabled] {
+  color: var(--typography-color-disabled);
+  cursor: not-allowed;
+}

--- a/packages/react-components/src/components/MenuItem/MenuItem.css
+++ b/packages/react-components/src/components/MenuItem/MenuItem.css
@@ -79,12 +79,7 @@ a.bcds-react-aria-MenuItem[data-disabled]
   background-color: var(--surface-color-menus-hover);
   outline: none;
 }
-.bcds-react-aria-MenuItem[data-focus-visible] {
-  outline: solid var(--layout-border-width-medium)
-    var(--surface-color-border-active);
-  outline-offset: var(--layout-margin-none);
-  border-radius: var(--layout-border-radius-small);
-}
+
 .bcds-react-aria-MenuItem[data-disabled] {
   color: var(--typography-color-disabled);
   cursor: not-allowed;

--- a/packages/react-components/src/components/MenuItem/MenuItem.test.tsx
+++ b/packages/react-components/src/components/MenuItem/MenuItem.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import Menu, { MenuTrigger } from "../Menu";
+import Button from "../Button";
+import MenuItem from "./MenuItem";
+
+async function renderOpenMenu(menuItem: React.ReactNode) {
+  render(
+    <MenuTrigger>
+      <Button>Open</Button>
+      <Menu aria-label="Actions">{menuItem}</Menu>
+    </MenuTrigger>
+  );
+
+  fireEvent.click(screen.getByRole("button", { name: /open/i }));
+  await screen.findByRole("menu");
+}
+
+describe("MenuItem", () => {
+  it("renders as a menu item with children text", async () => {
+    await renderOpenMenu(<MenuItem id="edit">Edit</MenuItem>);
+
+    const menuItem = await screen.findByRole("menuitem", { name: /edit/i });
+    expect(menuItem).toBeInTheDocument();
+    expect(menuItem).toHaveClass("bcds-react-aria-MenuItem medium");
+  });
+
+  it("applies small size class", async () => {
+    await renderOpenMenu(
+      <MenuItem id="edit" size="small">
+        Edit
+      </MenuItem>
+    );
+
+    expect(await screen.findByRole("menuitem", { name: /edit/i })).toHaveClass(
+      "bcds-react-aria-MenuItem small"
+    );
+  });
+
+  it("renders label and description content", async () => {
+    await renderOpenMenu(
+      <MenuItem id="share" label="Share" description="Send this item" />
+    );
+
+    expect(await screen.findByText("Share")).toBeInTheDocument();
+    expect(await screen.findByText("Send this item")).toBeInTheDocument();
+  });
+
+  it("renders left icon when iconLeft is passed", async () => {
+    await renderOpenMenu(
+      <MenuItem
+        id="profile"
+        iconLeft={<svg data-testid="left-icon" aria-label="left icon" />}
+      >
+        Profile
+      </MenuItem>
+    );
+
+    expect(await screen.findByTestId("left-icon")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("menuitem", { name: /profile/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/react-components/src/components/MenuItem/MenuItem.tsx
+++ b/packages/react-components/src/components/MenuItem/MenuItem.tsx
@@ -1,0 +1,69 @@
+import {
+  MenuItem as ReactAriaMenuItem,
+  MenuItemProps as ReactAriaMenuItemProps,
+  MenuItemRenderProps,
+  Text,
+} from "react-aria-components";
+
+import SvgCheckIcon from "../Icons/SvgCheckIcon";
+import SvgChevronRightIcon from "../Icons/SvgChevronRightIcon";
+
+import "./MenuItem.css";
+
+export interface MenuItemProps extends ReactAriaMenuItemProps {
+  label?: string;
+  description?: string;
+  size?: "small" | "medium";
+  iconLeft?: React.ReactElement;
+  children?:
+    | React.ReactNode
+    | ((
+        props: MenuItemRenderProps & { defaultChildren: React.ReactNode }
+      ) => React.ReactNode);
+}
+
+export default function MenuItem({
+  size = "medium",
+  label,
+  description,
+  iconLeft,
+  ...props
+}: MenuItemProps) {
+  /* Ensure textValue is set */
+  const textValue =
+    props.textValue ||
+    (typeof props.children === "string" ? props.children : undefined) ||
+    label;
+
+  return (
+    <ReactAriaMenuItem
+      {...props}
+      textValue={textValue}
+      className={`bcds-react-aria-MenuItem ${size}`}
+    >
+      {(
+        renderProps: MenuItemRenderProps & { defaultChildren: React.ReactNode }
+      ) => {
+        if (typeof props.children === "function") {
+          return props.children(renderProps);
+        }
+        return (
+          <>
+            {iconLeft && (
+              <span className="bcds-react-aria-MenuItem--Icon">{iconLeft}</span>
+            )}
+            {props.children}
+            {(label || description) && (
+              <div className="bcds-react-aria-MenuItem--Content">
+                {label && <Text slot="label">{label}</Text>}
+                {description && <Text slot="description">{description}</Text>}
+              </div>
+            )}
+            {renderProps.hasSubmenu && <SvgChevronRightIcon />}
+            {renderProps.isSelected && <SvgCheckIcon />}
+          </>
+        );
+      }}
+    </ReactAriaMenuItem>
+  );
+}

--- a/packages/react-components/src/components/MenuItem/index.ts
+++ b/packages/react-components/src/components/MenuItem/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./MenuItem";
+export type { MenuItemProps } from "./MenuItem";

--- a/packages/react-components/src/components/TextArea/TextArea.css
+++ b/packages/react-components/src/components/TextArea/TextArea.css
@@ -70,17 +70,17 @@
 }
 
 .bcds-react-aria-TextArea--Container:has(
-    > .bcds-react-aria-TextArea--Input[data-focused]
-  ),
+  > .bcds-react-aria-TextArea--Input[data-focused]
+),
 .bcds-react-aria-TextArea--Container:has(
-    > .bcds-react-aria-TextArea--Input[data-focused][data-hovered]
-  ) {
+  > .bcds-react-aria-TextArea--Input[data-focused][data-hovered]
+) {
   border-color: var(--surface-color-border-active);
 }
 
 .bcds-react-aria-TextArea--Container:has(
-    > .bcds-react-aria-TextArea--Input[data-focus-visible]
-  ) {
+  > .bcds-react-aria-TextArea--Input[data-focus-visible]
+) {
   border-radius: var(--layout-border-radius-large);
   border: var(--layout-border-width-small) solid
     var(--surface-color-border-active);
@@ -90,8 +90,8 @@
 }
 
 .bcds-react-aria-TextArea--Container:has(
-    > .bcds-react-aria-TextArea--Input[data-hovered]
-  ) {
+  > .bcds-react-aria-TextArea--Input[data-hovered]
+) {
   border-color: var(--surface-color-border-dark);
 }
 

--- a/packages/react-components/src/components/TextField/TextField.css
+++ b/packages/react-components/src/components/TextField/TextField.css
@@ -73,17 +73,17 @@
 }
 
 .bcds-react-aria-TextField--container:has(
-    > .bcds-react-aria-TextField--Input[data-focused]
-  ),
+  > .bcds-react-aria-TextField--Input[data-focused]
+),
 .bcds-react-aria-TextField--container:has(
-    > .bcds-react-aria-TextField--Input[data-focused][data-hovered]
-  ) {
+  > .bcds-react-aria-TextField--Input[data-focused][data-hovered]
+) {
   border-color: var(--surface-color-border-active);
 }
 
 .bcds-react-aria-TextField--container:has(
-    > .bcds-react-aria-TextField--Input[data-focus-visible]
-  ) {
+  > .bcds-react-aria-TextField--Input[data-focus-visible]
+) {
   border-radius: var(--layout-border-radius-large);
   border: var(--layout-border-width-small) solid
     var(--surface-color-border-active);

--- a/packages/react-components/src/components/index.ts
+++ b/packages/react-components/src/components/index.ts
@@ -18,6 +18,14 @@ export { default as Header } from "./Header";
 export { default as Heading } from "./Heading";
 export { default as InlineAlert } from "./InlineAlert";
 export { default as Link } from "./Link";
+export {
+  default as Menu,
+  MenuTrigger,
+  SubmenuTrigger,
+  MenuSection,
+  MenuSectionHeader,
+} from "./Menu";
+export { default as MenuItem } from "./MenuItem";
 export { default as Modal } from "./Modal";
 export { default as ProgressBar } from "./ProgressBar";
 export { default as ProgressCircle } from "./ProgressCircle";

--- a/packages/react-components/src/stories/Menu.mdx
+++ b/packages/react-components/src/stories/Menu.mdx
@@ -65,7 +65,7 @@ import * as MenuStories from "./Menu.stories";
 
 Learn more about working with the Menu component:
 
-- [Usage and best practice guidance](#)
+- [Usage and best practice guidance](https://www2.gov.bc.ca/gov/content?id=94129932F3384565A638034B69E0C943)
 - [View the Menu component in Figma](https://www2.gov.bc.ca/gov/content?id=8E36BE1D10E04A17B0CD4D913FA7AC43#designers)
 
 ## Controls

--- a/packages/react-components/src/stories/Menu.mdx
+++ b/packages/react-components/src/stories/Menu.mdx
@@ -1,0 +1,208 @@
+{/* Menu.mdx */}
+
+import {
+  Canvas,
+  Controls,
+  Meta,
+  Source,
+  Story,
+  Subtitle,
+} from "@storybook/addon-docs/blocks";
+
+import {
+  InlineAlert,
+  Link,
+  SvgUpRightFromSquareIcon,
+  SvgReactAriaIcon,
+} from "@/components";
+
+import * as MenuStories from "./Menu.stories";
+
+<Meta of={MenuStories} />
+
+# Menu
+
+<Subtitle>
+  A menu enables the user to select from a list of actions, options or links in
+  a dropdown.
+</Subtitle>
+
+<InlineAlert
+  variant="info"
+  customIcon={[<SvgReactAriaIcon />]}
+  title="This is a React Aria component"
+  description="It is based on the RA Menu component, its subcomponents and the Collections API. Consult the React Aria docs to understand its full API."
+  buttons={[
+    <Link
+      isButton
+      size="small"
+      buttonVariant="secondary"
+      href="https://react-aria.adobe.com/collections?component=Menu"
+      target="_blank"
+      iconRight={[<SvgUpRightFromSquareIcon size={16} />]}
+    >
+      Collections API docs
+    </Link>,
+    <Link
+      isButton
+      size="small"
+      buttonVariant="secondary"
+      href="https://react-aria.adobe.com/Menu"
+      target="_blank"
+      iconRight={[<SvgUpRightFromSquareIcon size={16} />]}
+    >
+      Menu docs
+    </Link>,
+  ]}
+/>
+
+## Usage and resources
+
+<Source
+  code={`import { Menu, MenuTrigger } from "@bcgov/design-system-react-components";`}
+  language="typescript"
+/>
+
+Learn more about working with the Menu component:
+
+- [Usage and best practice guidance](#)
+- [View the Menu component in Figma](https://www2.gov.bc.ca/gov/content?id=8E36BE1D10E04A17B0CD4D913FA7AC43#designers)
+
+## Controls
+
+<Canvas of={MenuStories.MenuTemplate} />
+<Controls of={MenuStories.MenuTemplate} />
+
+## Composition
+
+A menu comprises several parts:
+
+- A `<MenuTrigger>` wrapper
+- A trigger element (commonly a button)
+- A `<Menu>`, that renders a `<Popover>` containing some number of `<MenuItem>` elements
+
+Each element has its own API. Structurally, these components are assembled like this:
+
+```typescript
+import { Button, Menu, MenuTrigger } from "@bcgov/design-system-react-components";
+
+ function App() {
+   return (
+     <MenuTrigger>
+       <Button>This button activates the menu</Button>
+       <Menu />
+     </MenuTrigger>
+    );
+ }
+```
+
+There are three ways to compose a menu:
+
+- A flat list of `items`
+- A sectioned list using `sections` to provide an array of sections, each containing their own `items`
+- Manual composition via the `children` slot
+
+### `items`
+
+You can dynamically compose a menu using the `items` prop. `items` expects an array of objects, that will each be rendered as a [MenuItem](/docs/navigation-and-structure-menu-menuitem--docs):
+
+<Canvas of={MenuStories.Items} />
+
+Each item must have a unique `id` or `key`. If your `items` array doesn't match the shape of the MenuItem API, use a render function to map your properties or pass them as `children`:
+
+```typescript
+export default function App() {
+  const menuItems = [
+    { id: 1, icon: <SvgCheckCircleIcon />, name: "Link 1" },
+    { id: 2, icon: <SvgCheckCircleIcon />, name: "Link 2" },
+    { id: 3, icon: <SvgCheckCircleIcon />, name: "Link 3" },
+  ];
+
+  return (
+    <>
+      <MenuTrigger>
+        <Button variant="secondary">
+          Open the menu <SvgChevronDownIcon />
+        </Button>
+        <Menu items={menuItems}>
+          {(item) => <MenuItem iconLeft={item.icon} label={item.name} />}
+        </Menu>
+      </MenuTrigger>
+    </>
+  );
+}
+```
+
+### `sections`
+
+Breaking up a list into sections works similarly to populating a list via `items`. Pass an array of `sections`, each containing their own `items`:
+
+<Canvas of={MenuStories.SectionedMenu} />
+
+Each section should have its own `header` (label) and `id`.
+
+### Manual composition
+
+To manually compose a menu, import the subcomponents you need and assemble them as needed. This provides fine-grained control over menu structure and content:
+
+```javascript
+import {
+  Button,
+  Menu,
+  MenuItem,
+  MenuSection,
+  MenuSectionHeader,
+  MenuTrigger,
+  SubmenuTrigger,
+  Separator,
+} from "@bcgov/design-system-react-components";
+
+function App() {
+  return (
+    <MenuTrigger>
+      <Button>This button activates the menu</Button>
+      <Menu>
+        <MenuSection>
+          <MenuSectionHeader />
+          <MenuItem />
+        </MenuSection>
+        <Separator />
+        <MenuSection>
+          <MenuSectionHeader />
+          <MenuItem />
+        </MenuSection>
+      </Menu>
+    </MenuTrigger>
+  );
+}
+```
+
+## Configuration
+
+### Sizing
+
+The `size` prop lets you toggle a menu's items between `medium` (default) and `small` sizes:
+
+<Canvas of={MenuStories.SmallMenu} />
+
+**Note:** `size` is set on the `<Menu>` element, and does not affect the trigger element (e.g. the button.)
+
+### Popover placement
+
+Set `placement` on a `<Menu>` element to change where the popover appears:
+
+<Canvas of={MenuStories.PopoverPlacement} />
+
+### Submenus
+
+You can wrap a `<MenuItem>` in a `<SubmenuTrigger>`, and then nest another `<Menu>` underneath it. This will render inside a secondary popover:
+
+<Canvas of={MenuStories.Submenu} />
+
+**Note**: implementing submenus requires you to [manually compose the menu](#manual-composition).
+
+### Disabled items
+
+Set `isDisabled` on a single item to disable it, or disable multiple items by passing their IDs to `disabledKeys`:
+
+<Canvas of={MenuStories.DisabledItems} />

--- a/packages/react-components/src/stories/Menu.stories.tsx
+++ b/packages/react-components/src/stories/Menu.stories.tsx
@@ -21,7 +21,7 @@ const meta = {
     layout: "centered",
   },
   argTypes: {
-    size: {
+    itemSize: {
       options: ["small", "medium"],
       control: { type: "radio" },
       description:
@@ -113,7 +113,7 @@ type Story = StoryObj<typeof meta>;
 
 export const MenuTemplate: Story = {
   args: {
-    size: "medium",
+    itemSize: "medium",
     selectionMode: "single",
     placement: "bottom",
     children: [
@@ -167,7 +167,7 @@ export const Items: Story = {
 
 export const SmallMenu: Story = {
   args: {
-    size: "small",
+    itemSize: "small",
     items: [
       { id: 1, children: "Link 1" },
       { id: 2, children: "Link 2" },
@@ -216,7 +216,7 @@ export const SectionedMenu: Story = {
 
 export const Submenu: Story = {
   args: {
-    size: "medium",
+    itemSize: "medium",
     children: [
       <MenuSection key="section1">
         <MenuSectionHeader>Section 1</MenuSectionHeader>

--- a/packages/react-components/src/stories/Menu.stories.tsx
+++ b/packages/react-components/src/stories/Menu.stories.tsx
@@ -1,0 +1,294 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  Button,
+  Menu,
+  MenuItem,
+  MenuTrigger,
+  MenuSection,
+  MenuSectionHeader,
+  Separator,
+  SubmenuTrigger,
+  SvgChevronDownIcon,
+  SvgChevronRightIcon,
+  SvgCheckCircleIcon,
+} from "../components";
+
+const meta = {
+  title: "Navigation and structure/Menu",
+  component: Menu,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    size: {
+      options: ["small", "medium"],
+      control: { type: "radio" },
+      description:
+        "Sets the size of the menu items. Does not affect the `MenuTrigger` element",
+      table: {
+        defaultValue: { summary: "medium" },
+      },
+    },
+    items: {
+      control: { type: "object" },
+      description:
+        "Use for a simple list of menu items. Expects an array of objects with `MenuItem` props",
+    },
+    sections: {
+      control: { type: "object" },
+      description:
+        "Use for a sectioned menu. Expects an array of objects with `MenuSection` props, each containing an `items` array",
+    },
+    children: {
+      control: { type: "object" },
+      description:
+        "Use instead of `items` or `sections` to manually compose a menu",
+    },
+    placement: {
+      control: { type: "select" },
+      options: [
+        "bottom",
+        "bottom left",
+        "bottom right",
+        "bottom start",
+        "bottom end",
+        "top",
+        "top left",
+        "top right",
+        "top start",
+        "top end",
+        "left",
+        "left top",
+        "left bottom",
+        "start",
+        "start top",
+        "start bottom",
+        "right",
+        "right top",
+        "right bottom",
+        "end",
+        "end top",
+        "end bottom",
+      ],
+      table: {
+        defaultValue: { summary: "bottom" },
+      },
+      description: "The placement of the menu popover relative to the trigger",
+    },
+    autoFocus: {
+      options: [true, false, "first", "last"],
+      control: { type: "select" },
+      description: "Where the focus should be set",
+      table: {
+        defaultValue: { summary: "false" },
+      },
+    },
+    selectionMode: {
+      options: ["none", "single", "multiple"],
+      control: { type: "radio" },
+      description: "The type of selection that is allowed",
+    },
+    disallowEmptySelection: {
+      control: { type: "boolean" },
+      description: "Whether the menu allows empty selection",
+    },
+    selectedKeys: {
+      control: { type: "object" },
+      description: "The currently-selected keys in the menu (controlled)",
+    },
+    defaultSelectedKeys: {
+      control: { type: "object" },
+      description: "The initial selected keys in the menu (uncontrolled)",
+    },
+    disabledKeys: {
+      control: { type: "object" },
+      description: "The keys of the items that are disabled",
+    },
+  },
+} satisfies Meta<typeof Menu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MenuTemplate: Story = {
+  args: {
+    size: "medium",
+    selectionMode: "single",
+    placement: "bottom",
+    children: [
+      <MenuItem key={1} id={1}>
+        Link 1
+      </MenuItem>,
+      <MenuItem key={2} id={2}>
+        Link 2
+      </MenuItem>,
+      <MenuItem key={3} id={3}>
+        Link 3
+      </MenuItem>,
+      <MenuItem key={4} id={4}>
+        Link 4
+      </MenuItem>,
+    ],
+  },
+  render: ({ ...args }) => (
+    <MenuTrigger>
+      <Button variant="secondary">
+        Menu <SvgChevronDownIcon />
+      </Button>
+      <Menu {...args} />
+    </MenuTrigger>
+  ),
+};
+
+export const Items: Story = {
+  args: {
+    items: [
+      { id: 1, label: "Link 1", description: "Link 1 description" },
+      { id: 2, label: "Link 2", description: "Link 2 description" },
+      {
+        id: 3,
+
+        label: "Link 3",
+        description: "Link 3 description",
+        iconLeft: <SvgCheckCircleIcon />,
+      },
+    ],
+  },
+  render: ({ ...args }) => (
+    <MenuTrigger>
+      <Button variant="secondary">
+        Menu <SvgChevronDownIcon />
+      </Button>
+      <Menu {...args} />
+    </MenuTrigger>
+  ),
+};
+
+export const SmallMenu: Story = {
+  args: {
+    size: "small",
+    items: [
+      { id: 1, children: "Link 1" },
+      { id: 2, children: "Link 2" },
+    ],
+  },
+  render: ({ ...args }) => (
+    <MenuTrigger defaultOpen>
+      <Button variant="secondary" size="small">
+        Menu <SvgChevronDownIcon />
+      </Button>
+      <Menu {...args} />
+    </MenuTrigger>
+  ),
+};
+
+export const SectionedMenu: Story = {
+  args: {
+    sections: [
+      {
+        id: "section1",
+        header: "Section 1",
+        items: [
+          { id: 1, children: "Link 1" },
+          { id: 2, children: "Link 2" },
+        ],
+      },
+      {
+        id: "section2",
+        header: "Section 2",
+        items: [
+          { id: 3, children: "Link 3" },
+          { id: 4, children: "Link 4" },
+        ],
+      },
+    ],
+  },
+  render: ({ ...args }) => (
+    <MenuTrigger>
+      <Button variant="secondary" size="small">
+        Menu with sections <SvgChevronDownIcon />
+      </Button>
+      <Menu {...args} />
+    </MenuTrigger>
+  ),
+};
+
+export const Submenu: Story = {
+  args: {
+    size: "medium",
+    children: [
+      <MenuSection key="section1">
+        <MenuSectionHeader>Section 1</MenuSectionHeader>
+        <MenuItem>Link 1</MenuItem>
+        <MenuItem>Link 2</MenuItem>
+        <SubmenuTrigger>
+          <MenuItem>Submenu</MenuItem>
+          <Menu placement="right">
+            <MenuItem>Sublink 1</MenuItem>
+            <MenuItem>Sublink 2</MenuItem>
+          </Menu>
+        </SubmenuTrigger>
+      </MenuSection>,
+      <Separator key="separator" size="small" />,
+      <MenuSection key="section2">
+        <MenuSectionHeader>Section 2</MenuSectionHeader>
+        <MenuItem>Link 1</MenuItem>
+        <MenuItem>Link 2</MenuItem>
+        <SubmenuTrigger>
+          <MenuItem>Submenu</MenuItem>
+          <Menu>
+            <MenuItem>Sublink 1</MenuItem>
+            <MenuItem>Sublink 2</MenuItem>
+          </Menu>
+        </SubmenuTrigger>
+      </MenuSection>,
+    ],
+  },
+  render: ({ ...args }) => (
+    <MenuTrigger>
+      <Button variant="secondary">
+        Menu <SvgChevronDownIcon />
+      </Button>
+      <Menu {...args} />
+    </MenuTrigger>
+  ),
+};
+
+export const PopoverPlacement: Story = {
+  args: {
+    items: [
+      { id: 1, children: "Link 1" },
+      { id: 2, children: "Link 2" },
+    ],
+    placement: "right",
+  },
+  render: ({ ...args }) => (
+    <MenuTrigger>
+      <Button variant="secondary" size="small">
+        Menu with sections <SvgChevronRightIcon />
+      </Button>
+      <Menu {...args} />
+    </MenuTrigger>
+  ),
+};
+
+export const DisabledItems: Story = {
+  args: {
+    items: [
+      { id: 1, children: "Link 1" },
+      { id: 2, children: "Link 2" },
+      { id: 3, children: "Link 3" },
+      { id: 4, children: "Link 4" },
+    ],
+    disabledKeys: [2, 3],
+  },
+  render: ({ ...args }) => (
+    <MenuTrigger>
+      <Button variant="secondary">
+        Menu <SvgChevronDownIcon />
+      </Button>
+      <Menu {...args} />
+    </MenuTrigger>
+  ),
+};

--- a/packages/react-components/src/stories/MenuItem.mdx
+++ b/packages/react-components/src/stories/MenuItem.mdx
@@ -1,0 +1,100 @@
+{/* MenuItem.mdx */}
+
+import {
+  Canvas,
+  Controls,
+  Meta,
+  Source,
+  Story,
+  Subtitle,
+} from "@storybook/addon-docs/blocks";
+
+import {
+  InlineAlert,
+  Link,
+  SvgUpRightFromSquareIcon,
+  SvgReactAriaIcon,
+} from "@/components";
+
+import * as MenuItemStories from "./MenuItem.stories";
+
+<Meta of={MenuItemStories} />
+
+# Menu Item
+
+<Subtitle>
+  A MenuItem represents a single item within a
+  [Menu](/docs/navigation-and-structure-menu--docs).
+</Subtitle>
+
+<InlineAlert
+  variant="info"
+  customIcon={[<SvgReactAriaIcon />]}
+  title="This is a React Aria component"
+  description="It is based on the RA MenuItem component, its subcomponents and the Collections API. Consult the React Aria docs to understand its full API."
+  buttons={[
+    <Link
+      isButton
+      size="small"
+      buttonVariant="secondary"
+      href="https://react-aria.adobe.com/Menu#menuitem"
+      target="_blank"
+      iconRight={[<SvgUpRightFromSquareIcon size={16} />]}
+    >
+      MenuItem docs
+    </Link>,
+  ]}
+/>
+
+## Usage and resources
+
+<Source
+  code={`import { Menu, MenuItem, MenuTrigger } from "@bcgov/design-system-react-components";`}
+  language="typescript"
+/>
+
+MenuItem is a subcomponent used within a [Menu](/docs/navigation-and-structure-menu--docs) to represent a single item:
+
+```javascript
+import {
+  Button,
+  Menu,
+  MenuItem,
+  MenuTrigger,
+} from "@bcgov/design-system-react-components";
+
+function App() {
+  return (
+    <MenuTrigger>
+      <Button>This button activates the menu</Button>
+      <Menu>
+        <MenuItem />
+        <MenuItem />
+      </Menu>
+    </MenuTrigger>
+  );
+}
+```
+
+MenuItems are also generated dynamically by a Menu when the `items` or `sections` props are used.
+
+## Controls
+
+<Canvas of={MenuItemStories.MenuItemTemplate} />
+<Controls of={MenuItemStories.MenuItemTemplate} />
+
+## Configuration
+
+Configure a menu item's content using the `label`, `description` and `iconLeft` slots, or compose your own content via the generic `children` slot. Each menu item should also have a unique `id`.
+
+The `size` prop lets you toggle a menu item between `medium` (default) and `small` sizes. `size` can also be set on the parent `<Menu>` to apply it uniformly across all items.
+
+<Canvas of={MenuItemStories.SmallMenuItem} />
+
+Set an `href` to make a menu item a link. You can use `target`, `hrefLang` and `download` to customise link behaviour:
+
+<Canvas of={MenuItemStories.LinkedMenuItem} />
+
+Set `isDisabled` to disable a menu item:
+
+<Canvas of={MenuItemStories.DisabledMenuItem} />

--- a/packages/react-components/src/stories/MenuItem.stories.tsx
+++ b/packages/react-components/src/stories/MenuItem.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  Button,
+  Menu,
+  MenuItem,
+  MenuTrigger,
+  SvgChevronDownIcon,
+  SvgCheckCircleIcon,
+} from "../components";
+
+const meta = {
+  title: "Navigation and structure/Menu/MenuItem",
+  component: MenuItem,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    size: {
+      options: ["small", "medium"],
+      control: { type: "radio" },
+      description: "Sets the size of the menu item",
+    },
+    label: {
+      control: { type: "text" },
+      description: "Primary text label for the menu item",
+    },
+    description: {
+      control: { type: "text" },
+      description: "Secondary text description for the menu item",
+    },
+    iconLeft: {
+      control: { type: "object" },
+      description: "Adds an icon to the left of the menu item",
+    },
+    children: {
+      control: { type: "object" },
+      description:
+        "Content of the menu item, for use in place of `label` and `description`",
+    },
+    id: {
+      control: { type: "text" },
+      description: "Unique identifier for the menu item",
+    },
+    textValue: {
+      control: { type: "text" },
+      description:
+        "Used for typeahead and accessibility. Defaults to `children` if not set",
+    },
+    isDisabled: {
+      control: { type: "boolean" },
+      description: "Disables the menu item",
+    },
+    href: {
+      control: { type: "text" },
+      description: "A URL to link to",
+    },
+    target: {
+      control: { type: "text" },
+      description: "Target window for `href`",
+    },
+    download: {
+      control: { type: "text" },
+      description:
+        "Causes browser to download the linked URL instead of opening it",
+    },
+  },
+} satisfies Meta<typeof MenuItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MenuItemTemplate: Story = {
+  args: {
+    size: "medium",
+    label: "Menu item 1",
+    description: "Menu item description",
+    iconLeft: <SvgCheckCircleIcon />,
+  },
+  render: ({ ...args }) => (
+    <MenuTrigger>
+      <Button variant="secondary">
+        Menu <SvgChevronDownIcon />
+      </Button>
+      <Menu>
+        <MenuItem {...args} />
+      </Menu>
+    </MenuTrigger>
+  ),
+};
+
+export const SmallMenuItem: Story = {
+  ...MenuItemTemplate,
+  args: { ...MenuItemTemplate.args, size: "small" },
+};
+
+export const LinkedMenuItem: Story = {
+  ...MenuItemTemplate,
+  args: {
+    ...MenuItemTemplate.args,
+    label: "Linked menu item",
+    href: "https://www.example.org",
+    hrefLang: "en-US",
+    target: "_blank",
+  },
+};
+
+export const DisabledMenuItem: Story = {
+  ...MenuItemTemplate,
+  args: { ...MenuItemTemplate.args, isDisabled: true },
+};

--- a/packages/react-components/src/stories/MenuTrigger.mdx
+++ b/packages/react-components/src/stories/MenuTrigger.mdx
@@ -1,0 +1,94 @@
+{/* MenuTrigger.mdx */}
+
+import {
+  Canvas,
+  Controls,
+  Meta,
+  Source,
+  Story,
+  Subtitle,
+} from "@storybook/addon-docs/blocks";
+
+import {
+  InlineAlert,
+  Link,
+  SvgUpRightFromSquareIcon,
+  SvgReactAriaIcon,
+} from "@/components";
+
+import * as MenuTriggerStories from "./MenuTrigger.stories";
+
+<Meta of={MenuTriggerStories} />
+
+# Menu Trigger
+
+<Subtitle>
+  A MenuTrigger is a wrapper that connects a
+  [Menu](/docs/navigation-and-structure-menu--docs) and its trigger element.
+</Subtitle>
+
+<InlineAlert
+  variant="info"
+  customIcon={[<SvgReactAriaIcon />]}
+  title="This is a React Aria component"
+  description="It is based on the RA MenuTrigger component, its subcomponents and the Collections API. Consult the React Aria docs to understand its full API."
+  buttons={[
+    <Link
+      isButton
+      size="small"
+      buttonVariant="secondary"
+      href="https://react-aria.adobe.com/Menu#menutrigger"
+      target="_blank"
+      iconRight={[<SvgUpRightFromSquareIcon size={16} />]}
+    >
+      MenuTrigger docs
+    </Link>,
+  ]}
+/>
+
+## Usage and resources
+
+<Source
+  code={`import { Menu, MenuItem, MenuTrigger } from "@bcgov/design-system-react-components";`}
+  language="typescript"
+/>
+
+MenuTrigger is a wrapper used as the parent of a trigger element (like a [button](/docs/inputs-and-controls-button--docs)) and the [Menu](/docs/navigation-and-structure-menu--docs) it activates:
+
+```javascript
+import {
+  Button,
+  Menu,
+  MenuItem,
+  MenuTrigger,
+} from "@bcgov/design-system-react-components";
+
+function App() {
+  return (
+    <MenuTrigger>
+      <Button>This button activates the menu</Button>
+      <Menu>
+        <MenuItem />
+        <MenuItem />
+      </Menu>
+    </MenuTrigger>
+  );
+}
+```
+
+## Controls
+
+<Canvas of={MenuTriggerStories.MenuTriggerTemplate} />
+<Controls of={MenuTriggerStories.MenuTriggerTemplate} />
+
+## Configuration
+
+MenuTrigger's API lets you configure how the menu opens.
+
+Use the `defaultOpen` (uncontrolled) or `isOpen` (controlled) props to open a menu on render or based on another event.
+
+Use `onOpenChange` to provide an additional handler that is called when a Menu is opened or closed.
+
+Use `trigger` to change the action that opens a menu. By default this is `press`, but can also be set to `longPress`:
+
+<Canvas of={MenuTriggerStories.LongPress} />

--- a/packages/react-components/src/stories/MenuTrigger.stories.tsx
+++ b/packages/react-components/src/stories/MenuTrigger.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  Button,
+  Menu,
+  MenuItem,
+  MenuTrigger,
+  SvgChevronDownIcon,
+  SvgBcOutlineIcon,
+} from "../components";
+
+const meta = {
+  title: "Navigation and structure/Menu/MenuTrigger",
+  component: MenuTrigger,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    children: {
+      control: { type: "object" },
+      description: "The trigger element and menu content",
+    },
+    trigger: {
+      options: ["press", "longPress"],
+      control: { type: "radio" },
+    },
+    isOpen: {
+      control: { type: "boolean" },
+      description: "Whether the overlay is open by default (controlled)",
+    },
+    defaultOpen: {
+      control: { type: "boolean" },
+      description: "Whether the overlay is open by default (uncontrolled)",
+    },
+    onOpenChange: {
+      control: { type: "object" },
+      description:
+        "Handler that is called when the overlay's open state changes",
+    },
+  },
+} satisfies Meta<typeof MenuTrigger>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MenuTriggerTemplate: Story = {
+  args: {
+    children: [
+      <Button variant="secondary" key="trigger">
+        Menu <SvgChevronDownIcon />
+      </Button>,
+      <Menu key="menu">
+        <MenuItem
+          label="Menu item 1"
+          key="1"
+          description="Menu item description"
+          iconLeft={<SvgBcOutlineIcon />}
+        />
+      </Menu>,
+    ],
+    trigger: "press",
+  },
+  render: ({ ...args }) => <MenuTrigger {...args} />,
+};
+
+export const LongPress: Story = {
+  ...MenuTriggerTemplate,
+  args: {
+    ...MenuTriggerTemplate.args,
+    trigger: "longPress",
+  },
+};


### PR DESCRIPTION
Forking WIP on Menu component from #675 into a clean PR.

## Menu
<img width="681" height="348" alt="Screenshot 2026-03-19 at 2 28 06 PM" src="https://github.com/user-attachments/assets/eadf4e37-4d5f-4838-a4ab-71ceeea451e4" />

Menu is logically very similar to Select, and follows the same [Collections API](https://react-aria.adobe.com/collections). 

The `MenuTrigger`, `Menu` and `MenuItem` components are the core parts, but `MenuSection`, `MenuSection` and `SubmenuTrigger` components are also exported to support complex composition:

```javascript
function App() {
  return (
    <MenuTrigger>
      <Button>This button activates the menu</Button>
      <Menu>
        <MenuSection>
          <MenuSectionHeader />
          <MenuItem />
        </MenuSection>
        <Separator />
        <MenuSection>
          <MenuSectionHeader />
          <MenuItem />
        </MenuSection>
      </Menu>
    </MenuTrigger>
  );
}
```

Menus can be composed dynamically using the `items` or `sections` props, or manually composed via the `children` slot. 

See Storybook docs for a more detailed explanation of the structure of this set of components, and each component's individual API.