### PR TITLE
Remove redundant tag from GitHub Packages publish job

### DIFF
--- a/.github/workflows/publish_design_tokens.yaml
+++ b/.github/workflows/publish_design_tokens.yaml
@@ -228,8 +228,8 @@ jobs:
           registry-url: "https://npm.pkg.github.com/"
           scope: "@bcgov"
 
-      - name: Publish to GitHub Packages @latest
-        run: npm publish --tag latest --registry=https://npm.pkg.github.com/
+      - name: Publish to GitHub Packages
+        run: npm publish --registry=https://npm.pkg.github.com/
         working-directory: ./packages/design-tokens/dist
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish_react_component_library.yaml
+++ b/.github/workflows/publish_react_component_library.yaml
@@ -180,8 +180,8 @@ jobs:
           registry-url: "https://npm.pkg.github.com/"
           scope: "@bcgov"
 
-      - name: Publish to GitHub Packages @latest
-        run: npm publish --tag latest --registry=https://npm.pkg.github.com/
+      - name: Publish to GitHub Packages
+        run: npm publish --registry=https://npm.pkg.github.com/
         working-directory: ./packages/react-components
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This change removes the dist-tag (`--tag latest`) from the GitHub Packages publish jobs for new production versions. Unlike npm, this `latest` tag doesn't have a specialized role on GitHub Packages, and including it may cause issues. My suspicion is that:

- `npm install @bcgov/design-system-react-components@latest` would work
- `npm install @bcgov/design-system-react-components` without additional scope would not work as expected