### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Dependabot config
+# Docs: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#directories-or-directory--
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directories: ["/packages/react-components", "/packages/design-tokens"]
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "Canada/Pacific"
+    assignees: [mkernohanbc]
+    open-pull-requests-limit: 5
+    # Do not open PRs for major version updates
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,12 @@ updates:
       day: "monday"
       time: "04:00"
       timezone: "Canada/Pacific"
+    # Wait 7 days before opening PRs for new versions
+    cooldown:
+      default-days: 7
+      include: ["*"]
     assignees: [mkernohanbc]
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     # Do not open PRs for major version updates
     ignore:
       - dependency-name: "*"


### PR DESCRIPTION
This PR adds new [Dependabot](https://github.com/dependabot) config to give us a more structured approach to managing updates to the dependencies for `design-system-react-components` and `design-tokens`.

It configures Dependabot to perform a weekly scan for new versions of dependencies.

It applies two conditions:

- Only open PRs for minor/patch versions, ignore major versions (we handle these manually)
- Wait 7 days after a new version has released before opening a PR (as a defense against supply-chain attacks)