### PR TITLE
Design tokens v5.0.0

### DIFF
--- a/packages/design-tokens/CHANGELOG.md
+++ b/packages/design-tokens/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 5.0.0
+
+This is a milestone release that cross-publishes the design tokens library to GitHub Packages registry as well as npm.
+
+This release contains non-breaking changes to token values. There are no changes to token names.
+
+### Added
+
+- `@bcgov/design-tokens` is now installable from either the npm or GitHub Packages registries
+
+### Changed
+
+- Removed explicit line-height declaration from `typography.regular.display` and `typography.bold.display` tokens, so it will properly default to `normal`
+- Corrected value of `typography.lineHeights.auto` token from `AUTO` (Figma-generated) to `normal`
+- Re-ordered declarations for all `typography.italic.*` tokens to follow proper `font` shorthand order
+
+This release uses:
+
+- `@tokens-studio/sd-transforms` v2.0.3
+- `style-dictionary` v5.4.4
+
 ## 4.0.0
 
 This is a milestone release that adds SCSS as an output format.

--- a/packages/design-tokens/dist/package.json
+++ b/packages/design-tokens/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/design-tokens",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Design tokens for B.C. Design System",
   "repository": {
     "type": "git",

--- a/packages/design-tokens/package-lock.json
+++ b/packages/design-tokens/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "design-tokens",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "design-tokens",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@tokens-studio/sd-transforms": "2.0.3",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "design-tokens",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/bcgov/design-system.git",


### PR DESCRIPTION
This PR stages the release of `@bcgov/design-tokens` v5.0.0:

- Updates CHANGELOG
- Increments version number in `package.json` and `package-lock.json`