### PR TITLE
Menu: fix TypeScript error

### DIFF
--- a/packages/react-components/src/components/Menu/Menu.tsx
+++ b/packages/react-components/src/components/Menu/Menu.tsx
@@ -22,7 +22,7 @@ export interface MenuSectionProps {
   /* Text label for the section */
   header?: string;
   /* Array of items in the section */
-  items: MenuItemProps[];
+  items?: MenuItemProps[];
 }
 
 export interface MenuProps extends ReactAriaMenuProps<MenuItemProps> {

--- a/packages/react-components/src/components/Menu/Menu.tsx
+++ b/packages/react-components/src/components/Menu/Menu.tsx
@@ -25,27 +25,25 @@ export interface MenuSectionProps {
   items: MenuItemProps[];
 }
 
-export interface MenuProps<
-  T extends MenuItemProps,
-> extends ReactAriaMenuProps<T> {
+export interface MenuProps extends ReactAriaMenuProps<MenuItemProps> {
   /* Set size of menu items (does not affect the MenuTrigger element) */
   itemSize?: "small" | "medium";
   /* Use for a simple list menu */
-  items?: T[];
+  items?: MenuItemProps[];
   /* Use for a sectioned list with `items` in each section */
   sections?: MenuSectionProps[];
   /* Popover position */
   placement?: PopoverProps["placement"];
 }
 
-export default function Menu<T extends MenuItemProps>({
+export default function Menu({
   itemSize = "medium",
   children,
   items,
   sections,
   placement,
   ...props
-}: MenuProps<T>) {
+}: MenuProps) {
   /* Manual composition via children */
   if (children) {
     return (


### PR DESCRIPTION
This PR fixes a TypeScript error in the Menu component. Previously, there was an inconsistency in how the `items` prop (used to pass an array of menu items) was typed in the `MenuSectionProps` and `MenuProps` interfaces. In `MenuProps` it was typed as `items?: T[]`, which caused an incompatibility error with the `onAction` callback. 

With this change, `items` is now typed consistently as `items: MenuItemProps[]` in both contexts. This resolves the error, and is consistent with how we've approached this same functionality in Select.