### PR TITLE
Add Code Connect mappings for icons

### DIFF
--- a/packages/react-components/src/components/Calendar/Calendar.figma.ts
+++ b/packages/react-components/src/components/Calendar/Calendar.figma.ts
@@ -1,6 +1,6 @@
 // url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=15871%3A6832
 // source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Calendar/Calendar.tsx
-// component=Calendar
+// component=Calendar icon
 
 import figma from "figma";
 
@@ -13,7 +13,7 @@ const visibleDuration = figma.selectedInstance.getEnum("Visible months", {
 });
 
 export default {
-  id: "Calendar",
+  id: "Calendar icon",
   imports: [
     "import { Calendar } from '@bcgov/design-system-react-components';",
   ],

--- a/packages/react-components/src/components/Icons/SvgBcLogo/SvgBcLogo.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgBcLogo/SvgBcLogo.figma.ts
@@ -1,0 +1,14 @@
+// url= https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1788&t=yPX74R4GVseHsAvd-4
+// source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgBcLogo/SvgBcLogo.tsx
+// component=BC Logo
+
+import figma from "figma";
+
+export default {
+  id: "BC Logo",
+  imports: [
+    "import { SvgBcLogo } from '@bcgov/design-system-react-components';",
+  ],
+  example: figma.code`<SvgBcLogo />`,
+  metadata: { nestable: true },
+};

--- a/packages/react-components/src/components/Icons/SvgBcLogo/SvgBcLogo.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgBcLogo/SvgBcLogo.figma.ts
@@ -1,4 +1,4 @@
-// url= https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1788&t=yPX74R4GVseHsAvd-4
+// url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1788&t=yPX74R4GVseHsAvd-4
 // source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgBcLogo/SvgBcLogo.tsx
 // component=BC Logo
 

--- a/packages/react-components/src/components/Icons/SvgBcOutlineIcon/SvgBcOutlineIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgBcOutlineIcon/SvgBcOutlineIcon.figma.ts
@@ -5,7 +5,7 @@
 import figma from "figma";
 
 export default {
-  id: "20px/govbc/BC",
+  id: "BC Outline",
   imports: [
     "import { SvgBcOutlineIcon } from '@bcgov/design-system-react-components';",
   ],

--- a/packages/react-components/src/components/Icons/SvgBcOutlineIcon/SvgBcOutlineIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgBcOutlineIcon/SvgBcOutlineIcon.figma.ts
@@ -1,0 +1,14 @@
+// url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=5124-1014&t=yPX74R4GVseHsAvd-4
+// source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgBcOutlineIcon/SvgBcOutlineIcon.tsx
+// component=BC Outline
+
+import figma from "figma";
+
+export default {
+  id: "20px/govbc/BC",
+  imports: [
+    "import { SvgBcOutlineIcon } from '@bcgov/design-system-react-components';",
+  ],
+  example: figma.code`<SvgBcOutlineIcon />`,
+  metadata: { nestable: true },
+};

--- a/packages/react-components/src/components/Icons/SvgCalendarIcon/SvgCalendarIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgCalendarIcon/SvgCalendarIcon.figma.ts
@@ -1,0 +1,14 @@
+// url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=14595-5333&t=yPX74R4GVseHsAvd-4
+// source=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=14595-5333&t=yPX74R4GVseHsAvd-4
+// component=Calendar
+
+import figma from "figma";
+
+export default {
+  id: "Calendar",
+  imports: [
+    "import { SvgCalendarIcon } from '@bcgov/design-system-react-components';",
+  ],
+  example: figma.code`<SvgCalendarIcon />`,
+  metadata: { nestable: true },
+};

--- a/packages/react-components/src/components/Icons/SvgCalendarIcon/SvgCalendarIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgCalendarIcon/SvgCalendarIcon.figma.ts
@@ -1,5 +1,5 @@
 // url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=14595-5333&t=yPX74R4GVseHsAvd-4
-// source=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=14595-5333&t=yPX74R4GVseHsAvd-4
+// source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgCalendarIcon/SvgCalendarIcon.tsx
 // component=Calendar
 
 import figma from "figma";

--- a/packages/react-components/src/components/Icons/SvgCheckCircleIcon/SvgCheckCircleIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgCheckCircleIcon/SvgCheckCircleIcon.figma.ts
@@ -1,0 +1,14 @@
+// url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1752&t=yPX74R4GVseHsAvd-4
+// source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgCheckCircleIcon/SvgCheckCircleIcon.tsx
+// component=Check circle
+
+import figma from "figma";
+
+export default {
+  id: "Check circle",
+  imports: [
+    "import { SvgCheckCircleIcon } from '@bcgov/design-system-react-components';",
+  ],
+  example: figma.code`<SvgCheckCircleIcon />`,
+  metadata: { nestable: true },
+};

--- a/packages/react-components/src/components/Icons/SvgCheckIcon/SvgCheckIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgCheckIcon/SvgCheckIcon.figma.ts
@@ -1,0 +1,14 @@
+// url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1754&t=yPX74R4GVseHsAvd-4
+// source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgCheckIcon/SvgCheckIcon.tsx
+// component=Check
+
+import figma from "figma";
+
+export default {
+  id: "Check",
+  imports: [
+    "import { SvgCheckIcon } from '@bcgov/design-system-react-components';",
+  ],
+  example: figma.code`<SvgCheckIcon />`,
+  metadata: { nestable: true },
+};

--- a/packages/react-components/src/components/Icons/SvgChevronDownIcon/SvgChevronDownIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgChevronDownIcon/SvgChevronDownIcon.figma.ts
@@ -1,6 +1,6 @@
 // url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1738&t=yPX74R4GVseHsAvd-4
 // source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgChevronDownIcon/SvgChevronDownIcon.tsx
-// component=Chevron down
+// component=Chevron down icon
 
 import figma from "figma";
 

--- a/packages/react-components/src/components/Icons/SvgChevronDownIcon/SvgChevronDownIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgChevronDownIcon/SvgChevronDownIcon.figma.ts
@@ -1,0 +1,14 @@
+// url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1738&t=yPX74R4GVseHsAvd-4
+// source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgChevronDownIcon/SvgChevronDownIcon.tsx
+// component=Chevron down
+
+import figma from "figma";
+
+export default {
+  id: "Chevron down icon",
+  imports: [
+    "import { SvgChevronDownIcon } from '@bcgov/design-system-react-components';",
+  ],
+  example: figma.code`<SvgChevronDownIcon />`,
+  metadata: { nestable: true },
+};

--- a/packages/react-components/src/components/Icons/SvgChevronLeftIcon/SvgChevronLeftIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgChevronLeftIcon/SvgChevronLeftIcon.figma.ts
@@ -1,6 +1,6 @@
 // url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1740&t=yPX74R4GVseHsAvd-4
 // source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgChevronLeftIcon/SvgChevronLeftIcon.tsx
-// component=Chevron left
+// component=Chevron left icon
 
 import figma from "figma";
 

--- a/packages/react-components/src/components/Icons/SvgChevronLeftIcon/SvgChevronLeftIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgChevronLeftIcon/SvgChevronLeftIcon.figma.ts
@@ -1,0 +1,14 @@
+// url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1740&t=yPX74R4GVseHsAvd-4
+// source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgChevronLeftIcon/SvgChevronLeftIcon.tsx
+// component=Chevron left
+
+import figma from "figma";
+
+export default {
+  id: "Chevron left icon",
+  imports: [
+    "import { SvgChevronLeftIcon } from '@bcgov/design-system-react-components';",
+  ],
+  example: figma.code`<SvgChevronLeftIcon />`,
+  metadata: { nestable: true },
+};

--- a/packages/react-components/src/components/Icons/SvgChevronRightIcon/SvgChevronRightIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgChevronRightIcon/SvgChevronRightIcon.figma.ts
@@ -1,6 +1,6 @@
 // url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1742&t=yPX74R4GVseHsAvd-4
 // source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgChevronRightIcon/SvgChevronRightIcon.tsx
-// component=Chevron right
+// component=Chevron right icon
 
 import figma from "figma";
 

--- a/packages/react-components/src/components/Icons/SvgChevronRightIcon/SvgChevronRightIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgChevronRightIcon/SvgChevronRightIcon.figma.ts
@@ -1,0 +1,14 @@
+// url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1742&t=yPX74R4GVseHsAvd-4
+// source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgChevronRightIcon/SvgChevronRightIcon.tsx
+// component=Chevron right
+
+import figma from "figma";
+
+export default {
+  id: "Chevron right icon",
+  imports: [
+    "import { SvgChevronRightIcon } from '@bcgov/design-system-react-components';",
+  ],
+  example: figma.code`<SvgChevronRightIcon />`,
+  metadata: { nestable: true },
+};

--- a/packages/react-components/src/components/Icons/SvgChevronUpIcon/SvgChevronUpIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgChevronUpIcon/SvgChevronUpIcon.figma.ts
@@ -1,6 +1,6 @@
 // url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1744&t=yPX74R4GVseHsAvd-4
 // source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgChevronUpIcon/SvgChevronUpIcon.tsx
-// component=Chevron up
+// component=Chevron up icon
 
 import figma from "figma";
 

--- a/packages/react-components/src/components/Icons/SvgChevronUpIcon/SvgChevronUpIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgChevronUpIcon/SvgChevronUpIcon.figma.ts
@@ -1,0 +1,14 @@
+// url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1744&t=yPX74R4GVseHsAvd-4
+// source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgChevronUpIcon/SvgChevronUpIcon.tsx
+// component=Chevron up
+
+import figma from "figma";
+
+export default {
+  id: "Chevron up icon",
+  imports: [
+    "import { SvgChevronUpIcon } from '@bcgov/design-system-react-components';",
+  ],
+  example: figma.code`<SvgChevronUpIcon />`,
+  metadata: { nestable: true },
+};

--- a/packages/react-components/src/components/Icons/SvgCloseIcon/SvgCloseIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgCloseIcon/SvgCloseIcon.figma.ts
@@ -1,0 +1,14 @@
+// url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1728&m=dev
+// source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgCloseIcon/SvgCloseIcon.tsx
+// component=Close
+
+import figma from "figma";
+
+export default {
+  id: "Close icon",
+  imports: [
+    "import { SvgCloseIcon } from '@bcgov/design-system-react-components';",
+  ],
+  example: figma.code`<SvgCloseIcon />`,
+  metadata: { nestable: true },
+};

--- a/packages/react-components/src/components/Icons/SvgCloseIcon/SvgCloseIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgCloseIcon/SvgCloseIcon.figma.ts
@@ -1,6 +1,6 @@
 // url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1728&m=dev
 // source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgCloseIcon/SvgCloseIcon.tsx
-// component=Close
+// component=Close icon
 
 import figma from "figma";
 

--- a/packages/react-components/src/components/Icons/SvgExclamationCircleIcon/SvgExclamationCircleIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgExclamationCircleIcon/SvgExclamationCircleIcon.figma.ts
@@ -1,6 +1,6 @@
 // url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1746&t=yPX74R4GVseHsAvd-4
 // source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgExclamationCircleIcon/SvgExclamationCircleIcon.tsx
-// component=Exclamation circle
+// component=Exclamation circle icon
 
 import figma from "figma";
 

--- a/packages/react-components/src/components/Icons/SvgExclamationCircleIcon/SvgExclamationCircleIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgExclamationCircleIcon/SvgExclamationCircleIcon.figma.ts
@@ -1,0 +1,14 @@
+// url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1746&t=yPX74R4GVseHsAvd-4
+// source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgExclamationCircleIcon/SvgExclamationCircleIcon.tsx
+// component=Exclamation circle
+
+import figma from "figma";
+
+export default {
+  id: "Exclamation circle icon",
+  imports: [
+    "import { SvgExclamationCircleIcon } from '@bcgov/design-system-react-components';",
+  ],
+  example: figma.code`<SvgExclamationCircleIcon />`,
+  metadata: { nestable: true },
+};

--- a/packages/react-components/src/components/Icons/SvgExclamationIcon/SvgExclamationIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgExclamationIcon/SvgExclamationIcon.figma.ts
@@ -1,0 +1,14 @@
+// url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1750&t=yPX74R4GVseHsAvd-4
+// source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgExclamationIcon/SvgExclamationIcon.tsx
+// component=Exclamation triangle
+
+import figma from "figma";
+
+export default {
+  id: "Exclamation triangle",
+  imports: [
+    "import { SvgExclamationIcon } from '@bcgov/design-system-react-components';",
+  ],
+  example: figma.code`<SvgExclamationIcon />`,
+  metadata: { nestable: true },
+};

--- a/packages/react-components/src/components/Icons/SvgInfoIcon/SvgInfoIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgInfoIcon/SvgInfoIcon.figma.ts
@@ -1,0 +1,14 @@
+// url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1748&t=yPX74R4GVseHsAvd-4
+// source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgInfoIcon/SvgInfoIcon.tsx
+// component=Info circle
+
+import figma from "figma";
+
+export default {
+  id: "Info circle",
+  imports: [
+    "import { SvgInfoIcon } from '@bcgov/design-system-react-components';",
+  ],
+  example: figma.code`<SvgInfoIcon />`,
+  metadata: { nestable: true },
+};

--- a/packages/react-components/src/components/Icons/SvgMinusIcon/SvgMinusIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgMinusIcon/SvgMinusIcon.figma.ts
@@ -1,0 +1,14 @@
+// url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=14323-13122&t=yPX74R4GVseHsAvd-4
+// source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgMinusIcon/SvgMinusIcon.tsx
+// component=Minus
+
+import figma from "figma";
+
+export default {
+  id: "Minus",
+  imports: [
+    "import { SvgMinusIcon } from '@bcgov/design-system-react-components';",
+  ],
+  example: figma.code`<SvgMinusIcon />`,
+  metadata: { nestable: true },
+};

--- a/packages/react-components/src/components/Icons/SvgPlaceholderIcon/SvgPlaceholderIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgPlaceholderIcon/SvgPlaceholderIcon.figma.ts
@@ -1,0 +1,14 @@
+// url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=14242-12374&t=yPX74R4GVseHsAvd-4
+// source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgPlaceholderIcon/SvgPlaceholderIcon.tsx
+// component=Placeholder Icon
+
+import figma from "figma";
+
+export default {
+  id: "Placeholder icon",
+  imports: [
+    "import { SvgPlaceholderIcon } from '@bcgov/design-system-react-components';",
+  ],
+  example: figma.code`<SvgPlaceholderIcon />`,
+  metadata: { nestable: true },
+};

--- a/packages/react-components/src/components/Icons/SvgPlaceholderIcon/SvgPlaceholderIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgPlaceholderIcon/SvgPlaceholderIcon.figma.ts
@@ -1,6 +1,6 @@
 // url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=14242-12374&t=yPX74R4GVseHsAvd-4
 // source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgPlaceholderIcon/SvgPlaceholderIcon.tsx
-// component=Placeholder Icon
+// component=Placeholder icon
 
 import figma from "figma";
 

--- a/packages/react-components/src/components/Icons/SvgPlusIcon/SvgPlusIcon.figma.ts
+++ b/packages/react-components/src/components/Icons/SvgPlusIcon/SvgPlusIcon.figma.ts
@@ -1,0 +1,14 @@
+// url=https://www.figma.com/design/6BAmnRmL9FXxY2bkkSYiQj/B.C.-Design-System?node-id=3351-1756&t=yPX74R4GVseHsAvd-4
+// source=https://github.com/bcgov/design-system/blob/main/packages/react-components/src/components/Icons/SvgPlusIcon/SvgPlusIcon.tsx
+// component=Plus
+
+import figma from "figma";
+
+export default {
+  id: "Plus",
+  imports: [
+    "import { SvgPlusIcon } from '@bcgov/design-system-react-components';",
+  ],
+  example: figma.code`<SvgPlusIcon />`,
+  metadata: { nestable: true },
+};


### PR DESCRIPTION
This PR closes #670. It adds Code Connect mapping files for icons that currently exist as components in **both** Figma and React.

There are a small number of React components that aren't used in Figma, and a larger number of icon components in Figma that aren't currently represented in React.

This change doesn't touch existing code — it simply adds new `*.figma.ts` files alongside each component. Currently, the mappings are basic (i.e. they just point to the right component to import.) The icon components in Figma don't have much in the way of their own controls or properties, so this change is independent of #760.