### PR TITLE
Test workflows: set correct download path for build artifacts

### DIFF
--- a/.github/workflows/test_publish_design_tokens.yaml
+++ b/.github/workflows/test_publish_design_tokens.yaml
@@ -75,6 +75,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: design-tokens-build
+          path: packages/design-tokens/dist
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -99,6 +100,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: design-tokens-build
+          path: packages/design-tokens/dist
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -126,6 +128,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: design-tokens-build
+          path: packages/design-tokens/dist
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -150,6 +153,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: design-tokens-build
+          path: packages/design-tokens/dist
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/test_publish_react_component_library.yaml
+++ b/.github/workflows/test_publish_react_component_library.yaml
@@ -73,6 +73,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: react-components-build
+          path: packages/react-components
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -96,6 +97,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: react-components-build
+          path: packages/react-components
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -122,6 +124,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: react-components-build
+          path: packages/react-components
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -145,6 +148,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: react-components-build
+          path: packages/react-components
 
       - name: Set up Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
Attempt to fix this job failure in the test workflows from #762: https://github.com/bcgov/design-system/actions/runs/28268823077/job/83761783124