### PR TITLE
remove auto-assign from Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
     cooldown:
       default-days: 7
       include: ["*"]
-    assignees: [mkernohanbc]
     open-pull-requests-limit: 10
     # Do not open PRs for major version updates
     ignore:


### PR DESCRIPTION
Remove redundant auto-assignment of Dependabot PRs. Dependabot automatically requests review from the @bcgov/design-system-developers team via CODEOWNERS.