### PR TITLE
NumberField: remove hardcoded minValue

### DIFF
--- a/packages/react-components/src/components/NumberField/NumberField.tsx
+++ b/packages/react-components/src/components/NumberField/NumberField.tsx
@@ -32,13 +32,14 @@ export default function NumberField({
   size = "medium",
   label,
   description,
+  minValue = 0,
   errorMessage,
   ...props
 }: NumberFieldProps) {
   return (
     <ReactAriaNumberField
       className={`bcds-react-aria-NumberField ${size}`}
-      minValue={0}
+      minValue={minValue}
       {...props}
     >
       {({ isRequired, isInvalid }: ReactAriaNumberFieldRenderProps) => (


### PR DESCRIPTION
This change corrects an error in how `minValue` is handled in NumberField, that surfaced during some testing work.

NumberField previously had its `minValue` hardcoded to `0` — which is the desired default behaviour, but would also potentially cause issues if someone wanted to set a different `minValue`.

This change destructures `minValue` in order to set the desired default, without hard-coding it.