### PR TITLE
Use absolute URL from production Storybook site for /react-components redirect

### DIFF
--- a/packages/react-components/nginx.storybook.conf
+++ b/packages/react-components/nginx.storybook.conf
@@ -40,7 +40,11 @@ http {
 
     # Redirect /react-components to /react-components/
     location = /react-components {
-      return 301 /react-components/;
+      # This uses the canonical production URL for the React Storybook
+      # deployment because Nginx won't have enough context to cleanly generate
+      # a redirect back to /react-components/ otherwise. It will instead attempt
+      # an `http://` address with the port `:8080` appended to the domain.
+      return 301 https://designsystem.gov.bc.ca/react-components/;
     }
 
     # Redirect 404 errors to the Design System landing page


### PR DESCRIPTION
This PR adjusts the React component library's Storybook Nginx configuration file to fix a redirect bug.

When a user requests `/react-components`, we have a redirect that attempts to direct them to `/react-components/` with a trailing `/`. Storybook requires the trailing slash to work properly. In practice, this redirect doesn't work in production because Nginx tries to build an `http://` version of the URL, including the port `:8080`.

To solve, this PR updates the `/react-components` location to redirect to the canonical production URL `https://designsystem.gov.bc.ca/react-components/`. It is slightly sub-optimal to use the production URL because our `dev` and `test` environments will also redirect to the production URL when accessed at the `/react-components` path, but I think it's worth the trade to have the redirect working in production as expected.

If we find this doesn't work or it breaks something else, we can revert.