### PR TITLE
Update GitHub Actions and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 # Dependabot config
 # Docs: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
+
 version: 2
 updates:
+  # Dependency updates for @bcgov/design-tokens and @bcgov/design-system-react-components
   - package-ecosystem: "npm"
     directories: ["/packages/react-components", "/packages/design-tokens"]
     schedule:
@@ -32,3 +34,21 @@ updates:
       typescript-eslint:
         applies-to: version-updates
         patterns: ["typescript-eslint", "@typescript-eslint/*"]
+
+  # Dependency updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "Canada/Pacific"
+    # Wait 7 days before opening PRs for new versions
+    cooldown:
+      default-days: 7
+      include: ["*"]
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns: ["actions/*"]

--- a/.github/workflows/build_react_component_library_apps.yaml
+++ b/.github/workflows/build_react_component_library_apps.yaml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build_react_component_library_apps.yaml
+++ b/.github/workflows/build_react_component_library_apps.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           driver-opts: network=host
 
@@ -35,7 +35,7 @@ jobs:
         run: docker build ./packages/react-components/ -f ./packages/react-components/Dockerfile.storybook -t design-system-react-components-storybook:latest --build-arg GITHUB_SHA=${{ github.sha }}
 
       - name: Login to OpenShift Silver image registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: image-registry.apps.silver.devops.gov.bc.ca
           # This refers to the serviceaccount name alone, not the fully qualified
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           driver-opts: network=host
 
@@ -68,7 +68,7 @@ jobs:
         run: docker build ./packages/react-components/ -f ./packages/react-components/Dockerfile.storybook -t design-system-react-components-storybook:latest --build-arg GITHUB_SHA=${{ github.sha }}
 
       - name: Login to OpenShift Silver image registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: image-registry.apps.silver.devops.gov.bc.ca
           # This refers to the serviceaccount name alone, not the fully qualified
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           driver-opts: network=host
 
@@ -101,7 +101,7 @@ jobs:
         run: docker build ./packages/react-components/ -f ./packages/react-components/Dockerfile.vite -t design-system-react-components-vite:latest
 
       - name: Login to OpenShift Silver image registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: image-registry.apps.silver.devops.gov.bc.ca
           username: ${{ secrets.OPENSHIFT_SILVER_SERVICEACCOUNT_USERNAME }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,9 +30,8 @@ jobs:
         uses: bcgov/devhub-techdocs-publish@stable
         id: build_and_publish
         with:
-          publish: "true" # publishing disabled initially - content will be built, but not published. repositories need to be granted access to TechDocs secrets explicitly by the DevEx team before publishing would work, so we disable to prevent the workflow from failing.
-          # the parameters below can be uncommented when publishing is enabled and secrets have been exposed to the repo
-          production: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }} # example of only pushing to prod DevHub when changes that triggered the job are in main branch
+          publish: "true"
+          production: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
           bucket_name: ${{ secrets.TECHDOCS_S3_BUCKET_NAME }}
           s3_access_key_id: ${{ secrets.TECHDOCS_AWS_ACCESS_KEY_ID }}
           s3_secret_access_key: ${{ secrets.TECHDOCS_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,41 +1,40 @@
 name: Build TechDocs with DevHub TechDocs Publish Action
 permissions:
-    contents: read
+  contents: read
 on:
-    workflow_dispatch:
-    push:
-        branches: [ main ]
-        paths:
-            - "mkdocs.yml"
-            - "docs/*"
-            - "catalog-info.yaml"
-    pull_request:
-        branches: [ main ]
-        paths:
-            - "mkdocs.yml"
-            - "docs/*"
-            - "catalog-info.yaml"
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "mkdocs.yml"
+      - "docs/*"
+      - "catalog-info.yaml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "mkdocs.yml"
+      - "docs/*"
+      - "catalog-info.yaml"
 
 jobs:
-    test_techdocs_build_job:
-        runs-on: ubuntu-latest
+  test_techdocs_build_job:
+    runs-on: ubuntu-latest
 
-        name: A job to build and publish techdocs content
-        steps:
-            -   name: Checkout
-                uses: actions/checkout@v4
-                with:
-                    fetch-depth: '0'
-            -   name: Build TechDocs
-                uses: bcgov/devhub-techdocs-publish@stable
-                id: build_and_publish
-                with:
-                    publish: 'true' # publishing disabled initially - content will be built, but not published. repositories need to be granted access to TechDocs secrets explicitly by the DevEx team before publishing would work, so we disable to prevent the workflow from failing.
-# the parameters below can be uncommented when publishing is enabled and secrets have been exposed to the repo                    
-                    production:  ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }} # example of only pushing to prod DevHub when changes that triggered the job are in main branch
-                    bucket_name: ${{ secrets.TECHDOCS_S3_BUCKET_NAME }}
-                    s3_access_key_id: ${{ secrets.TECHDOCS_AWS_ACCESS_KEY_ID }}
-                    s3_secret_access_key: ${{ secrets.TECHDOCS_AWS_SECRET_ACCESS_KEY }}
-                    s3_region: ${{ secrets.TECHDOCS_AWS_REGION }}
-                    s3_endpoint: ${{ secrets.TECHDOCS_AWS_ENDPOINT }}
-
+    name: A job to build and publish techdocs content
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: "0"
+      - name: Build TechDocs
+        uses: bcgov/devhub-techdocs-publish@stable
+        id: build_and_publish
+        with:
+          publish: "true" # publishing disabled initially - content will be built, but not published. repositories need to be granted access to TechDocs secrets explicitly by the DevEx team before publishing would work, so we disable to prevent the workflow from failing.
+          # the parameters below can be uncommented when publishing is enabled and secrets have been exposed to the repo
+          production: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }} # example of only pushing to prod DevHub when changes that triggered the job are in main branch
+          bucket_name: ${{ secrets.TECHDOCS_S3_BUCKET_NAME }}
+          s3_access_key_id: ${{ secrets.TECHDOCS_AWS_ACCESS_KEY_ID }}
+          s3_secret_access_key: ${{ secrets.TECHDOCS_AWS_SECRET_ACCESS_KEY }}
+          s3_region: ${{ secrets.TECHDOCS_AWS_REGION }}
+          s3_endpoint: ${{ secrets.TECHDOCS_AWS_ENDPOINT }}

--- a/.github/workflows/test_design_tokens_build.yaml
+++ b/.github/workflows/test_design_tokens_build.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Read .nvmrc
         run: echo "GITHUB_NVMRC_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV

--- a/.github/workflows/test_design_tokens_build.yaml
+++ b/.github/workflows/test_design_tokens_build.yaml
@@ -27,7 +27,7 @@ jobs:
         working-directory: ./packages/design-tokens
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.GITHUB_NVMRC_VERSION }}
 

--- a/.github/workflows/test_react_component_library.yaml
+++ b/.github/workflows/test_react_component_library.yaml
@@ -27,7 +27,7 @@ jobs:
         working-directory: ./packages/react-components
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.GITHUB_NVMRC_VERSION }}
 
@@ -74,7 +74,7 @@ jobs:
         working-directory: ./packages/react-components
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.GITHUB_NVMRC_VERSION }}
 

--- a/.github/workflows/test_react_component_library.yaml
+++ b/.github/workflows/test_react_component_library.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Read .nvmrc
         run: echo "GITHUB_NVMRC_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Read .nvmrc
         run: echo "GITHUB_NVMRC_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV


### PR DESCRIPTION
This PR:

1. Updates actions used in our workflows to their latest versions
2. Pins all action versions to the release SHA
3. Adds new Dependabot config to handle future updates to actions

It does not touch these two workflows:

- `publish_design_tokens.yaml‎`
- `publish_react_component_library.yaml‎`

These changes are applied to those workflows in #770 ([f74eb9d](https://github.com/bcgov/design-system/pull/770/commits/f74eb9ddf3c704686860e510416b6b4ee69f6271))