### PR TITLE
[DS-18] Checkbox: adopt new React Aria API

### DIFF
--- a/packages/react-components/src/components/Checkbox/Checkbox.css
+++ b/packages/react-components/src/components/Checkbox/Checkbox.css
@@ -7,7 +7,7 @@
 }
 
 /* Checkbox */
-.bcds-react-aria-Checkbox > .checkbox {
+.bcds-react-aria-Checkbox > .bcds-react-aria-Checkbox--Indicator {
   align-self: first baseline;
   display: flex;
   margin-top: var(--layout-margin-hair);
@@ -21,43 +21,48 @@
   border-width: var(--layout-border-width-small);
   border-radius: var(--layout-border-radius-small);
 }
-.bcds-react-aria-Checkbox > .checkbox > svg {
+.bcds-react-aria-Checkbox > .bcds-react-aria-Checkbox--Indicator > svg {
   align-self: center;
 }
 
 /* Label */
-.bcds-react-aria-Checkbox > .label {
+.bcds-react-aria-Checkbox > .bcds-react-aria-Checkbox--Label {
   font: var(--typography-regular-small-body);
   color: var(--typography-color-secondary);
 }
 
 /* Focus */
-.bcds-react-aria-Checkbox[data-focus-visible] > .checkbox {
+.bcds-react-aria-Checkbox[data-focus-visible]
+  > .bcds-react-aria-Checkbox--Indicator {
   outline: solid var(--layout-border-width-medium)
     var(--surface-color-border-active);
   outline-offset: var(--layout-margin-hair);
 }
 
 /* Hover */
-.bcds-react-aria-Checkbox[data-hovered] > .checkbox {
+.bcds-react-aria-Checkbox[data-hovered] > .bcds-react-aria-Checkbox--Indicator {
   border-color: var(--surface-color-border-dark);
 }
-.bcds-react-aria-Checkbox[data-selected][data-hovered] > .checkbox {
+.bcds-react-aria-Checkbox[data-selected][data-hovered]
+  > .bcds-react-aria-Checkbox--Indicator {
   background-color: var(--surface-color-primary-hover);
   border-color: var(--surface-color-primary-hover);
 }
 
 /* Pressed */
-.bcds-react-aria-Checkbox[data-pressed] > .checkbox {
+.bcds-react-aria-Checkbox[data-pressed] > .bcds-react-aria-Checkbox--Indicator {
   background-color: var(--surface-color-primary-default);
 }
 
 /* Selected */
-.bcds-react-aria-Checkbox[data-selected] > .checkbox {
+.bcds-react-aria-Checkbox[data-selected]
+  > .bcds-react-aria-Checkbox--Indicator {
   background-color: var(--surface-color-primary-default);
   border-color: var(--surface-color-primary-default);
 }
-.bcds-react-aria-Checkbox[data-selected] > .checkbox > svg {
+.bcds-react-aria-Checkbox[data-selected]
+  > .bcds-react-aria-Checkbox--Indicator
+  > svg {
   color: var(--icons-color-primary-invert);
 }
 
@@ -65,39 +70,50 @@
 .bcds-react-aria-Checkbox[data-disabled] {
   cursor: not-allowed;
 }
-.bcds-react-aria-Checkbox[data-disabled] > .checkbox {
+.bcds-react-aria-Checkbox[data-disabled]
+  > .bcds-react-aria-Checkbox--Indicator {
   border-color: var(--surface-color-border-medium);
   background-color: var(--surface-color-primary-disabled);
 }
-.bcds-react-aria-Checkbox[data-disabled] > .label {
+.bcds-react-aria-Checkbox[data-disabled] > .bcds-react-aria-Checkbox--Label {
   color: var(--typography-color-disabled);
 }
-.bcds-react-aria-Checkbox[data-selected][data-disabled] > .checkbox {
+.bcds-react-aria-Checkbox[data-selected][data-disabled]
+  > .bcds-react-aria-Checkbox--Indicator {
   border-color: var(--surface-color-primary-disabled);
   background-color: var(--surface-color-primary-disabled);
 }
-.bcds-react-aria-Checkbox[data-selected][data-disabled] > .checkbox > svg {
+.bcds-react-aria-Checkbox[data-selected][data-disabled]
+  > .bcds-react-aria-Checkbox--Indicator
+  > svg {
   color: var(--icons-color-disabled);
 }
 
 /* Indeterminate */
-.bcds-react-aria-Checkbox[data-indeterminate] > .checkbox {
+.bcds-react-aria-Checkbox[data-indeterminate]
+  > .bcds-react-aria-Checkbox--Indicator {
   background-color: var(--surface-color-primary-default);
   border-color: var(--surface-color-primary-default);
 }
-.bcds-react-aria-Checkbox[data-indeterminate][data-disabled] > .checkbox {
+.bcds-react-aria-Checkbox[data-indeterminate][data-disabled]
+  > .bcds-react-aria-Checkbox--Indicator {
   background-color: var(--surface-color-primary-disabled);
   border-color: var(--surface-color-primary-disabled);
 }
-.bcds-react-aria-Checkbox[data-indeterminate][data-invalid] > .checkbox {
+.bcds-react-aria-Checkbox[data-indeterminate][data-invalid]
+  > .bcds-react-aria-Checkbox--Indicator {
   background-color: var(--surface-color-primary-danger-button-default);
 }
-.bcds-react-aria-Checkbox[data-indeterminate] > .checkbox > svg {
+.bcds-react-aria-Checkbox[data-indeterminate]
+  > .bcds-react-aria-Checkbox--Indicator
+  > svg {
   color: var(--icons-color-primary-invert);
   align-self: center;
   vertical-align: middle;
 }
-.bcds-react-aria-Checkbox[data-indeterminate][data-disabled] > .checkbox > svg {
+.bcds-react-aria-Checkbox[data-indeterminate][data-disabled]
+  > .bcds-react-aria-Checkbox--Indicator
+  > svg {
   color: var(--icons-color-disabled);
 }
 
@@ -107,12 +123,15 @@
 }
 
 /* Invalid */
-.bcds-react-aria-Checkbox[data-invalid] > .checkbox {
+.bcds-react-aria-Checkbox[data-invalid] > .bcds-react-aria-Checkbox--Indicator {
   border-color: var(--support-border-color-danger);
 }
-.bcds-react-aria-Checkbox[data-invalid] > .checkbox > svg {
+.bcds-react-aria-Checkbox[data-invalid]
+  > .bcds-react-aria-Checkbox--Indicator
+  > svg {
   color: var(--icons-color-primary-invert);
 }
-.bcds-react-aria-Checkbox[data-selected][data-invalid] > .checkbox {
+.bcds-react-aria-Checkbox[data-selected][data-invalid]
+  > .bcds-react-aria-Checkbox--Indicator {
   background-color: var(--surface-color-primary-danger-button-default);
 }

--- a/packages/react-components/src/components/Checkbox/Checkbox.css
+++ b/packages/react-components/src/components/Checkbox/Checkbox.css
@@ -47,6 +47,16 @@
   );
 }
 
+/* Error */
+.bcds-react-aria-Checkbox--Error {
+  font: var(--typography-regular-label);
+  color: var(--typography-color-danger);
+  /* Offset to align with the label text */
+  margin-left: calc(
+    var(--icons-size-small) + (var(--layout-border-width-small) * 2) + 10px
+  );
+}
+
 /* Focus */
 .bcds-react-aria-Checkbox--Button[data-focus-visible]
   > .bcds-react-aria-Checkbox--Indicator {
@@ -59,11 +69,6 @@
 .bcds-react-aria-Checkbox--Button[data-hovered]
   > .bcds-react-aria-Checkbox--Indicator {
   border-color: var(--surface-color-border-dark);
-}
-.bcds-react-aria-Checkbox--Button[data-selected][data-hovered]
-  > .bcds-react-aria-Checkbox--Indicator {
-  background-color: var(--surface-color-primary-hover);
-  border-color: var(--surface-color-primary-hover);
 }
 
 /* Pressed */
@@ -95,18 +100,6 @@
     color: var(--typography-color-disabled);
   }
 }
-.bcds-react-aria-Checkbox[data-disabled][data-selected] {
-  .bcds-react-aria-Checkbox--Button {
-    cursor: not-allowed;
-  }
-  .bcds-react-aria-Checkbox--Indicator {
-    border-color: var(--surface-color-primary-disabled);
-    background-color: var(--surface-color-primary-disabled);
-    > svg {
-      color: var(--icons-color-disabled);
-    }
-  }
-}
 
 /* Indeterminate */
 .bcds-react-aria-Checkbox[data-indeterminate] {
@@ -119,19 +112,6 @@
       vertical-align: middle;
     }
   }
-}
-.bcds-react-aria-Checkbox[data-indeterminate][data-disabled] {
-  .bcds-react-aria-Checkbox--Indicator {
-    background-color: var(--surface-color-primary-disabled);
-    border-color: var(--surface-color-primary-disabled);
-    > svg {
-      color: var(--icons-color-disabled);
-    }
-  }
-}
-.bcds-react-aria-Checkbox--Button[data-indeterminate][data-invalid]
-  > .bcds-react-aria-Checkbox--Indicator {
-  background-color: var(--surface-color-primary-danger-button-default);
 }
 
 /* Read-only */
@@ -148,14 +128,48 @@
     }
   }
 }
-.bcds-react-aria-Checkbox--Error {
-  font: var(--typography-regular-label);
-  color: var(--typography-color-danger);
-  /* Offset to align with the label text */
-  margin-left: calc(
-    var(--icons-size-small) + (var(--layout-border-width-small) * 2) + 10px
-  );
+
+/* Compound states */
+
+/* Selected + Hovered */
+.bcds-react-aria-Checkbox--Button[data-selected][data-hovered]
+  > .bcds-react-aria-Checkbox--Indicator {
+  background-color: var(--surface-color-primary-hover);
+  border-color: var(--surface-color-primary-hover);
 }
+
+/* Disabled + Selected */
+.bcds-react-aria-Checkbox[data-disabled][data-selected] {
+  .bcds-react-aria-Checkbox--Button {
+    cursor: not-allowed;
+  }
+  .bcds-react-aria-Checkbox--Indicator {
+    border-color: var(--surface-color-primary-disabled);
+    background-color: var(--surface-color-primary-disabled);
+    > svg {
+      color: var(--icons-color-disabled);
+    }
+  }
+}
+
+/* Indeterminate + Disabled */
+.bcds-react-aria-Checkbox[data-indeterminate][data-disabled] {
+  .bcds-react-aria-Checkbox--Indicator {
+    background-color: var(--surface-color-primary-disabled);
+    border-color: var(--surface-color-primary-disabled);
+    > svg {
+      color: var(--icons-color-disabled);
+    }
+  }
+}
+
+/* Indeterminate + Invalid */
+.bcds-react-aria-Checkbox--Button[data-indeterminate][data-invalid]
+  > .bcds-react-aria-Checkbox--Indicator {
+  background-color: var(--surface-color-primary-danger-button-default);
+}
+
+/* Invalid + Selected */
 .bcds-react-aria-Checkbox[data-selected][data-invalid] {
   .bcds-react-aria-Checkbox--Indicator {
     background-color: var(--surface-color-primary-danger-button-default);

--- a/packages/react-components/src/components/Checkbox/Checkbox.css
+++ b/packages/react-components/src/components/Checkbox/Checkbox.css
@@ -1,13 +1,19 @@
 .bcds-react-aria-Checkbox {
-  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: var(--layout-margin-xsmall);
+}
+
+.bcds-react-aria-Checkbox--Button {
   display: flex;
   flex-direction: row;
   gap: 10px;
   align-items: center;
+  cursor: pointer;
 }
 
 /* Checkbox */
-.bcds-react-aria-Checkbox > .bcds-react-aria-Checkbox--Indicator {
+.bcds-react-aria-Checkbox--Indicator {
   align-self: first baseline;
   display: flex;
   margin-top: var(--layout-margin-hair);
@@ -21,18 +27,28 @@
   border-width: var(--layout-border-width-small);
   border-radius: var(--layout-border-radius-small);
 }
-.bcds-react-aria-Checkbox > .bcds-react-aria-Checkbox--Indicator > svg {
+.bcds-react-aria-Checkbox--Indicator > svg {
   align-self: center;
 }
 
 /* Label */
-.bcds-react-aria-Checkbox > .bcds-react-aria-Checkbox--Label {
+.bcds-react-aria-Checkbox--Label {
   font: var(--typography-regular-small-body);
   color: var(--typography-color-secondary);
 }
 
+/* Description */
+.bcds-react-aria-Checkbox--Description {
+  font: var(--typography-regular-label);
+  color: var(--typography-color-secondary);
+  /* Offset to align with the label text */
+  margin-left: calc(
+    var(--icons-size-small) + (var(--layout-border-width-small) * 2) + 10px
+  );
+}
+
 /* Focus */
-.bcds-react-aria-Checkbox[data-focus-visible]
+.bcds-react-aria-Checkbox--Button[data-focus-visible]
   > .bcds-react-aria-Checkbox--Indicator {
   outline: solid var(--layout-border-width-medium)
     var(--surface-color-border-active);
@@ -40,98 +56,108 @@
 }
 
 /* Hover */
-.bcds-react-aria-Checkbox[data-hovered] > .bcds-react-aria-Checkbox--Indicator {
+.bcds-react-aria-Checkbox--Button[data-hovered]
+  > .bcds-react-aria-Checkbox--Indicator {
   border-color: var(--surface-color-border-dark);
 }
-.bcds-react-aria-Checkbox[data-selected][data-hovered]
+.bcds-react-aria-Checkbox--Button[data-selected][data-hovered]
   > .bcds-react-aria-Checkbox--Indicator {
   background-color: var(--surface-color-primary-hover);
   border-color: var(--surface-color-primary-hover);
 }
 
 /* Pressed */
-.bcds-react-aria-Checkbox[data-pressed] > .bcds-react-aria-Checkbox--Indicator {
+.bcds-react-aria-Checkbox--Button[data-pressed]
+  > .bcds-react-aria-Checkbox--Indicator {
   background-color: var(--surface-color-primary-default);
 }
 
 /* Selected */
-.bcds-react-aria-Checkbox[data-selected]
+.bcds-react-aria-Checkbox--Button[data-selected]
   > .bcds-react-aria-Checkbox--Indicator {
   background-color: var(--surface-color-primary-default);
   border-color: var(--surface-color-primary-default);
-}
-.bcds-react-aria-Checkbox[data-selected]
-  > .bcds-react-aria-Checkbox--Indicator
   > svg {
-  color: var(--icons-color-primary-invert);
+    color: var(--icons-color-primary-invert);
+  }
 }
 
 /* Disabled */
 .bcds-react-aria-Checkbox[data-disabled] {
-  cursor: not-allowed;
+  .bcds-react-aria-Checkbox--Button {
+    cursor: not-allowed;
+  }
+  .bcds-react-aria-Checkbox--Indicator {
+    border-color: var(--surface-color-border-medium);
+    background-color: var(--surface-color-primary-disabled);
+  }
+  .bcds-react-aria-Checkbox--Label {
+    color: var(--typography-color-disabled);
+  }
 }
-.bcds-react-aria-Checkbox[data-disabled]
-  > .bcds-react-aria-Checkbox--Indicator {
-  border-color: var(--surface-color-border-medium);
-  background-color: var(--surface-color-primary-disabled);
-}
-.bcds-react-aria-Checkbox[data-disabled] > .bcds-react-aria-Checkbox--Label {
-  color: var(--typography-color-disabled);
-}
-.bcds-react-aria-Checkbox[data-selected][data-disabled]
-  > .bcds-react-aria-Checkbox--Indicator {
-  border-color: var(--surface-color-primary-disabled);
-  background-color: var(--surface-color-primary-disabled);
-}
-.bcds-react-aria-Checkbox[data-selected][data-disabled]
-  > .bcds-react-aria-Checkbox--Indicator
-  > svg {
-  color: var(--icons-color-disabled);
+.bcds-react-aria-Checkbox[data-disabled][data-selected] {
+  .bcds-react-aria-Checkbox--Button {
+    cursor: not-allowed;
+  }
+  .bcds-react-aria-Checkbox--Indicator {
+    border-color: var(--surface-color-primary-disabled);
+    background-color: var(--surface-color-primary-disabled);
+    > svg {
+      color: var(--icons-color-disabled);
+    }
+  }
 }
 
 /* Indeterminate */
-.bcds-react-aria-Checkbox[data-indeterminate]
-  > .bcds-react-aria-Checkbox--Indicator {
-  background-color: var(--surface-color-primary-default);
-  border-color: var(--surface-color-primary-default);
+.bcds-react-aria-Checkbox[data-indeterminate] {
+  .bcds-react-aria-Checkbox--Indicator {
+    background-color: var(--surface-color-primary-default);
+    border-color: var(--surface-color-primary-default);
+    > svg {
+      color: var(--icons-color-primary-invert);
+      align-self: center;
+      vertical-align: middle;
+    }
+  }
 }
-.bcds-react-aria-Checkbox[data-indeterminate][data-disabled]
-  > .bcds-react-aria-Checkbox--Indicator {
-  background-color: var(--surface-color-primary-disabled);
-  border-color: var(--surface-color-primary-disabled);
+.bcds-react-aria-Checkbox[data-indeterminate][data-disabled] {
+  .bcds-react-aria-Checkbox--Indicator {
+    background-color: var(--surface-color-primary-disabled);
+    border-color: var(--surface-color-primary-disabled);
+    > svg {
+      color: var(--icons-color-disabled);
+    }
+  }
 }
-.bcds-react-aria-Checkbox[data-indeterminate][data-invalid]
+.bcds-react-aria-Checkbox--Button[data-indeterminate][data-invalid]
   > .bcds-react-aria-Checkbox--Indicator {
   background-color: var(--surface-color-primary-danger-button-default);
 }
-.bcds-react-aria-Checkbox[data-indeterminate]
-  > .bcds-react-aria-Checkbox--Indicator
-  > svg {
-  color: var(--icons-color-primary-invert);
-  align-self: center;
-  vertical-align: middle;
-}
-.bcds-react-aria-Checkbox[data-indeterminate][data-disabled]
-  > .bcds-react-aria-Checkbox--Indicator
-  > svg {
-  color: var(--icons-color-disabled);
-}
 
 /* Read-only */
-.bcds-react-aria-Checkbox[data-readonly] {
+.bcds-react-aria-Checkbox--Button[data-readonly] {
   cursor: not-allowed;
 }
 
 /* Invalid */
-.bcds-react-aria-Checkbox[data-invalid] > .bcds-react-aria-Checkbox--Indicator {
-  border-color: var(--support-border-color-danger);
+.bcds-react-aria-Checkbox[data-invalid] {
+  .bcds-react-aria-Checkbox--Indicator {
+    border-color: var(--support-border-color-danger);
+    > svg {
+      color: var(--icons-color-primary-invert);
+    }
+  }
 }
-.bcds-react-aria-Checkbox[data-invalid]
-  > .bcds-react-aria-Checkbox--Indicator
-  > svg {
-  color: var(--icons-color-primary-invert);
+.bcds-react-aria-Checkbox--Error {
+  font: var(--typography-regular-label);
+  color: var(--typography-color-danger);
+  /* Offset to align with the label text */
+  margin-left: calc(
+    var(--icons-size-small) + (var(--layout-border-width-small) * 2) + 10px
+  );
 }
-.bcds-react-aria-Checkbox[data-selected][data-invalid]
-  > .bcds-react-aria-Checkbox--Indicator {
-  background-color: var(--surface-color-primary-danger-button-default);
+.bcds-react-aria-Checkbox[data-selected][data-invalid] {
+  .bcds-react-aria-Checkbox--Indicator {
+    background-color: var(--surface-color-primary-danger-button-default);
+  }
 }

--- a/packages/react-components/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-components/src/components/Checkbox/Checkbox.tsx
@@ -1,7 +1,9 @@
 import {
-  Checkbox as ReactAriaCheckbox,
-  CheckboxProps,
-  CheckboxRenderProps,
+  CheckboxButton,
+  CheckboxField,
+  CheckboxFieldProps,
+  FieldError,
+  ValidationResult,
 } from "react-aria-components";
 
 import SvgCheckIcon from "../Icons/SvgCheckIcon";
@@ -9,24 +11,37 @@ import SvgDashIcon from "../Icons/SvgDashIcon";
 
 import "./Checkbox.css";
 
-export default function Checkbox({ value, children, ...props }: CheckboxProps) {
+export interface CheckboxProps extends CheckboxFieldProps {
+  /* Sets text label for checkbox */
+  children?: React.ReactNode;
+  /* Sets optional description text below label */
+  description?: string;
+  /* Used for data validation and error handling */
+  errorMessage?: string | ((validation: ValidationResult) => string);
+}
+
+export default function Checkbox({
+  value,
+  children,
+  errorMessage,
+  ...props
+}: CheckboxProps) {
   return (
-    <ReactAriaCheckbox
-      className="bcds-react-aria-Checkbox"
-      value={value}
-      {...props}
-    >
-      {({ isRequired, isSelected, isIndeterminate }: CheckboxRenderProps) => (
-        <>
-          <div className="checkbox">
-            {isSelected && !isIndeterminate && <SvgCheckIcon />}
-            {isIndeterminate && <SvgDashIcon />}
-          </div>
-          <span className="label">
-            <>{children}</> {isRequired && "(required)"}
-          </span>
-        </>
-      )}
-    </ReactAriaCheckbox>
+    <CheckboxField value={value} {...props}>
+      <CheckboxButton className="bcds-react-aria-Checkbox">
+        {({ isRequired, isSelected, isIndeterminate }) => (
+          <>
+            <div className="bcds-react-aria-Checkbox--Indicator">
+              {isSelected && !isIndeterminate && <SvgCheckIcon />}
+              {isIndeterminate && <SvgDashIcon />}
+            </div>
+            <span className="bcds-react-aria-Checkbox--Label">
+              <>{children}</> {isRequired && "(required)"}
+            </span>
+          </>
+        )}
+      </CheckboxButton>
+      <FieldError>{errorMessage}</FieldError>
+    </CheckboxField>
   );
 }

--- a/packages/react-components/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-components/src/components/Checkbox/Checkbox.tsx
@@ -3,6 +3,7 @@ import {
   CheckboxField,
   CheckboxFieldProps,
   FieldError,
+  Text,
   ValidationResult,
 } from "react-aria-components";
 
@@ -23,12 +24,17 @@ export interface CheckboxProps extends CheckboxFieldProps {
 export default function Checkbox({
   value,
   children,
+  description,
   errorMessage,
   ...props
 }: CheckboxProps) {
   return (
-    <CheckboxField value={value} {...props}>
-      <CheckboxButton className="bcds-react-aria-Checkbox">
+    <CheckboxField
+      className="bcds-react-aria-Checkbox"
+      value={value}
+      {...props}
+    >
+      <CheckboxButton className="bcds-react-aria-Checkbox--Button">
         {({ isRequired, isSelected, isIndeterminate }) => (
           <>
             <div className="bcds-react-aria-Checkbox--Indicator">
@@ -41,7 +47,17 @@ export default function Checkbox({
           </>
         )}
       </CheckboxButton>
-      <FieldError>{errorMessage}</FieldError>
+      {description && (
+        <Text
+          slot="description"
+          className="bcds-react-aria-Checkbox--Description"
+        >
+          {description}
+        </Text>
+      )}
+      <FieldError className="bcds-react-aria-Checkbox--Error">
+        {errorMessage}
+      </FieldError>
     </CheckboxField>
   );
 }

--- a/packages/react-components/src/components/Checkbox/index.ts
+++ b/packages/react-components/src/components/Checkbox/index.ts
@@ -1,2 +1,2 @@
 export { default } from "./Checkbox";
-export type { CheckboxProps } from "react-aria-components";
+export type { CheckboxProps } from "./Checkbox";

--- a/packages/react-components/src/stories/Checkbox.stories.tsx
+++ b/packages/react-components/src/stories/Checkbox.stories.tsx
@@ -18,6 +18,10 @@ const meta = {
       control: { type: "object" },
       description: "Text label",
     },
+    description: {
+      control: { type: "text" },
+      description: "Optional description text below label",
+    },
     defaultSelected: {
       control: { type: "boolean" },
       description: "Whether a checkbox is selected by default",
@@ -58,6 +62,13 @@ export const CheckboxTemplate: Story = {
   render: ({ ...args }: CheckboxProps) => <Checkbox {...args} />,
 };
 
+export const CheckboxWithDescription: Story = {
+  args: {
+    children: "This is a checkbox label",
+    description: "This is a description for the checkbox",
+  },
+};
+
 export const DefaultSelectedCheckbox: Story = {
   args: {
     children: "This checkbox is selected by default",
@@ -91,5 +102,14 @@ export const IndeterminateCheckbox: Story = {
   args: {
     children: "This checkbox is neither selected nor deselected",
     isIndeterminate: true,
+  },
+};
+
+export const InvalidCheckbox: Story = {
+  args: {
+    children: "This checkbox is invalid",
+    description: "You have to select this checkbox",
+    isInvalid: true,
+    errorMessage: "It displays an additional error message",
   },
 };

--- a/packages/react-components/src/stories/CheckboxGroup.mdx
+++ b/packages/react-components/src/stories/CheckboxGroup.mdx
@@ -101,6 +101,10 @@ Each component has its own set of supported props.
 
 Each checkbox should also have a unique identifier, set using the `value` prop. This is used for data validation and submission. If two checkboxes have the same `value`, selecting one will set both to `isSelected`.
 
+Use `description` to provide additional text below the checkbox label:
+
+<Canvas of={CheckboxStories.CheckboxWithDescription} />
+
 Use `defaultSelected` to make a checkbox selected by default:
 
 <Canvas of={CheckboxStories.DefaultSelectedCheckbox} />
@@ -124,6 +128,12 @@ A checkbox can be put in [an 'indeterminate' (mixed/uncertain) state](https://re
 <Canvas of={CheckboxStories.IndeterminateCheckbox} />
 
 `isIndeterminate` overrides the checkbox's appearance, until it is set to `false` (for example, conditionally based on other selections.)
+
+When a checkbox is marked as invalid via `isInvalid`, it displays an additional message:
+
+<Canvas of={CheckboxStories.InvalidCheckbox} />
+
+Checkbox uses the FieldError subcomponent to render error messages. You can pass custom or dynamically-generated content to the `errorMessage` slot.
 
 ## CheckboxGroup
 


### PR DESCRIPTION
This PR closes #720. It refactors the Checkbox component to adopt the new API shipped in `react-aria-components` v1.18.0. Checkbox now uses the `CheckboxField` and `CheckboxButton` subcomponents internally. Checkbox now supports additional description and error message fields, displayed underneath the main text label. This change is non-breaking. This PR also includes a refactor of Checkbox's CSS to conform to stylelint's `no-descending-specificity` rule (see #841.)





---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>