### PR TITLE
[DS-19] Radio: adopt new React Aria API

### DIFF
--- a/packages/react-components/src/components/Radio/Radio.css
+++ b/packages/react-components/src/components/Radio/Radio.css
@@ -1,16 +1,34 @@
 .bcds-react-aria-Radio {
+  display: flex;
+  flex-direction: column;
+  gap: var(--layout-margin-xsmall);
+}
+
+.bcds-react-aria-Radio--Button {
   cursor: pointer;
   display: flex;
   flex-direction: row;
   align-items: center;
   gap: var(--layout-margin-small);
-  font: var(--typography-regular-small-body);
-  color: var(--typography-color-secondary);
   forced-color-adjust: none;
 }
 
+/* Label */
+.bcds-react-aria-Radio--Label {
+  font: var(--typography-regular-small-body);
+  color: var(--typography-color-secondary);
+}
+
+/* Description */
+.bcds-react-aria-Radio--Description {
+  font: var(--typography-regular-label);
+  color: var(--typography-color-secondary);
+  /* Offset to align with the label text */
+  margin-left: calc(var(--icons-size-xsmall) + var(--layout-margin-small));
+}
+
 /* Selector */
-.bcds-react-aria-Radio::before {
+.bcds-react-aria-Radio--Indicator {
   align-self: first baseline;
   margin-top: var(--layout-margin-xsmall);
   content: "";
@@ -25,58 +43,60 @@
   transition: all 200ms;
 }
 @media (prefers-reduced-motion) {
-  .bcds-react-aria-Radio::before {
+  .bcds-react-aria-Radio--Indicator {
     /* No animation on radio button circle if user has reduced motion set */
     transition: none;
   }
 }
 
 /* Hover */
-.bcds-react-aria-Radio[data-hovered]::before {
+.bcds-react-aria-Radio[data-hovered] .bcds-react-aria-Radio--Indicator {
   border: var(--layout-border-width-small) solid
     var(--surface-color-border-dark);
 }
 
 /* Pressed */
-.bcds-react-aria-Radio[data-pressed]::before {
+.bcds-react-aria-Radio[data-pressed] .bcds-react-aria-Radio--Indicator {
   border: var(--layout-border-width-small) solid
     var(--surface-color-border-dark);
 }
 
 /* Selected */
-.bcds-react-aria-Radio[data-selected]::before {
+.bcds-react-aria-Radio[data-selected] .bcds-react-aria-Radio--Indicator {
   border: 5px solid var(--surface-color-primary-default);
 }
 
 /* Focused */
-.bcds-react-aria-Radio[data-focus-visible]::before {
+.bcds-react-aria-Radio[data-focus-visible] .bcds-react-aria-Radio--Indicator {
   outline: solid var(--layout-border-width-medium)
     var(--surface-color-border-active);
   outline-offset: var(--layout-margin-hair);
 }
 
 /* Invalid */
-.bcds-react-aria-Radio[data-invalid]::before {
+.bcds-react-aria-Radio[data-invalid] .bcds-react-aria-Radio--Indicator {
   border: var(--layout-border-width-small) solid
     var(--support-border-color-danger);
 }
 .bcds-react-aria-Radio[data-selected][data-invalid] {
   color: var(--typography-color-danger);
-}
-.bcds-react-aria-Radio[data-selected][data-invalid]::before {
-  border: 5px solid var(--support-border-color-danger);
-}
 
-/* Disabled */
-.bcds-react-aria-Radio[data-disabled] {
-  color: var(--typography-color-disabled);
-  cursor: not-allowed;
-}
-.bcds-react-aria-Radio[data-selected][data-disabled]::before {
-  border: 5px solid var(--surface-color-border-default);
-}
+  .bcds-react-aria-Radio--Indicator {
+    border: 5px solid var(--support-border-color-danger);
+  }
 
-/* Read only */
-.bcds-react-aria-Radio[data-readonly] {
-  cursor: not-allowed;
+  /* Disabled */
+  .bcds-react-aria-Radio[data-disabled] {
+    color: var(--typography-color-disabled);
+    cursor: not-allowed;
+  }
+  .bcds-react-aria-Radio[data-selected][data-disabled]
+    .bcds-react-aria-Radio--Indicator {
+    border: 5px solid var(--surface-color-border-default);
+  }
+
+  /* Read only */
+  .bcds-react-aria-Radio[data-readonly] {
+    cursor: not-allowed;
+  }
 }

--- a/packages/react-components/src/components/Radio/Radio.css
+++ b/packages/react-components/src/components/Radio/Radio.css
@@ -67,7 +67,8 @@
 }
 
 /* Focused */
-.bcds-react-aria-Radio[data-focus-visible] .bcds-react-aria-Radio--Indicator {
+.bcds-react-aria-Radio--Button[data-focus-visible]
+  .bcds-react-aria-Radio--Indicator {
   outline: solid var(--layout-border-width-medium)
     var(--surface-color-border-active);
   outline-offset: var(--layout-margin-hair);

--- a/packages/react-components/src/components/Radio/Radio.css
+++ b/packages/react-components/src/components/Radio/Radio.css
@@ -78,25 +78,37 @@
   border: var(--layout-border-width-small) solid
     var(--support-border-color-danger);
 }
+
+/* Disabled */
+.bcds-react-aria-Radio[data-disabled] {
+  .bcds-react-aria-Radio--Button {
+    cursor: not-allowed;
+  }
+  .bcds-react-aria-Radio--Label {
+    color: var(--typography-color-disabled);
+  }
+}
+
+/* Read only */
+.bcds-react-aria-Radio[data-readonly] {
+  .bcds-react-aria-Radio--Button {
+    cursor: not-allowed;
+  }
+}
+
+/* Compound states */
+
+/* Selected + Invalid */
 .bcds-react-aria-Radio[data-selected][data-invalid] {
   color: var(--typography-color-danger);
 
   .bcds-react-aria-Radio--Indicator {
     border: 5px solid var(--support-border-color-danger);
   }
+}
 
-  /* Disabled */
-  .bcds-react-aria-Radio[data-disabled] {
-    color: var(--typography-color-disabled);
-    cursor: not-allowed;
-  }
-  .bcds-react-aria-Radio[data-selected][data-disabled]
-    .bcds-react-aria-Radio--Indicator {
-    border: 5px solid var(--surface-color-border-default);
-  }
-
-  /* Read only */
-  .bcds-react-aria-Radio[data-readonly] {
-    cursor: not-allowed;
-  }
+/* Selected + Disabled */
+.bcds-react-aria-Radio[data-selected][data-disabled]
+  .bcds-react-aria-Radio--Indicator {
+  border: 5px solid var(--surface-color-border-default);
 }

--- a/packages/react-components/src/components/Radio/Radio.tsx
+++ b/packages/react-components/src/components/Radio/Radio.tsx
@@ -1,11 +1,36 @@
-import { Radio as ReactAriaRadio, RadioProps } from "react-aria-components";
+import {
+  RadioField,
+  RadioButton,
+  RadioFieldProps as ReactAriaRadioFieldProps,
+  Text,
+} from "react-aria-components";
 
 import "./Radio.css";
 
-export default function Radio({ value, children, ...props }: RadioProps) {
+export interface RadioProps extends ReactAriaRadioFieldProps {
+  /* Sets text label for radio button */
+  children?: React.ReactNode;
+  /* Sets optional description text below label */
+  description?: string;
+}
+
+export default function Radio({
+  value,
+  children,
+  description,
+  ...props
+}: RadioProps) {
   return (
-    <ReactAriaRadio className="bcds-react-aria-Radio" value={value} {...props}>
-      {children}
-    </ReactAriaRadio>
+    <RadioField className="bcds-react-aria-Radio" value={value} {...props}>
+      <RadioButton className="bcds-react-aria-Radio--Button">
+        <div className="bcds-react-aria-Radio--Indicator" />
+        <span className="bcds-react-aria-Radio--Label">{children}</span>
+      </RadioButton>
+      {description && (
+        <Text slot="description" className="bcds-react-aria-Radio--Description">
+          {description}
+        </Text>
+      )}
+    </RadioField>
   );
 }

--- a/packages/react-components/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/packages/react-components/src/components/RadioGroup/RadioGroup.test.tsx
@@ -28,9 +28,11 @@ describe("RadioGroup", () => {
   });
 
   it("user can select a radio input option with a click", () => {
-    const optionOne: HTMLFormElement = screen.getByTestId("one");
-    expect(optionOne).not.toHaveAttribute("data-selected");
+    const optionOne: HTMLInputElement = screen.getByRole("radio", {
+      name: /option 1/i,
+    });
+    expect(optionOne).not.toBeChecked();
     fireEvent.click(optionOne);
-    expect(optionOne).toHaveAttribute("data-selected");
+    expect(optionOne).toBeChecked();
   });
 });

--- a/packages/react-components/src/stories/RadioGroup.mdx
+++ b/packages/react-components/src/stories/RadioGroup.mdx
@@ -80,6 +80,7 @@ Each `Radio` expects:
 
 - A unique identifier, set via the `value` prop
 - A text label, passed to the `children` slot
+- Optionally, additional helper text set via the `description` slot
 
 <Canvas of={RadioGroupStories.RadioGroupTemplate} />
 

--- a/packages/react-components/src/stories/RadioGroup.stories.tsx
+++ b/packages/react-components/src/stories/RadioGroup.stories.tsx
@@ -50,7 +50,7 @@ export const RadioGroupTemplate: Story = {
       <Radio value="1" key="1">
         Option 1
       </Radio>,
-      <Radio value="2" key="2">
+      <Radio value="2" key="2" description="This option also has a description">
         Option 2
       </Radio>,
       <Radio value="3" key="3">


### PR DESCRIPTION
This PR closes #721. It refactors the Radio component to adopt the new API shipped in `react-aria-components` v1.18.0. Radio now uses the `RadioField` and `RadioButton` subcomponents internally. Radio now supports an additional description field, displayed below the main text label. This change is non-breaking. This PR also includes a refactor of Radio's CSS to conform to stylelint's `no-descending-specificity` rule (see #841.)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>