### PR TITLE
[DS-20] Switch: adopt new React Aria API

### DIFF
--- a/packages/react-components/src/components/Switch/Switch.css
+++ b/packages/react-components/src/components/Switch/Switch.css
@@ -1,14 +1,45 @@
 .bcds-react-aria-Switch {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   gap: var(--layout-margin-small);
   font: var(--typography-regular-small-body);
   color: var(--typography-color-secondary);
   forced-color-adjust: none;
 }
 
-/* Container */
-.bcds-react-aria-Switch > .indicator {
+/* Button */
+.bcds-react-aria-Switch--Button {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--layout-margin-small);
+}
+
+/* Description */
+.bcds-react-aria-Switch--Description {
+  font: var(--typography-regular-label);
+  color: var(--typography-color-secondary);
+}
+
+/* Error message */
+.bcds-react-aria-Switch--Error {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  font: var(--typography-regular-small-body);
+  color: var(--typography-color-danger);
+  > svg {
+    padding-right: var(--layout-padding-xsmall);
+    color: var(--icons-color-danger);
+    width: var(--icons-size-medium);
+    height: var(--icons-size-medium);
+  }
+}
+
+/* Track */
+.bcds-react-aria-Switch--Track {
   align-items: center;
   width: var(--layout-margin-xxlarge);
   height: var(--icons-size-medium);
@@ -17,15 +48,14 @@
   transition: all 200ms;
 }
 @media (prefers-reduced-motion) {
-  /* No animation on Switch container color if user has reduced motion set */
-  .bcds-react-aria-Switch > .indicator {
+  /* No animation on Switch track color if user has reduced motion set */
+  .bcds-react-aria-Switch--Button > .bcds-react-aria-Switch--Track {
     transition: none;
   }
 }
 
-/* Indicator */
-.bcds-react-aria-Switch > .indicator::before {
-  content: "";
+/* Handle */
+.bcds-react-aria-Switch--Handle {
   display: block;
   box-sizing: border-box;
   width: var(--icons-size-medium);
@@ -37,66 +67,69 @@
   transition: all 200ms;
 }
 @media (prefers-reduced-motion) {
-  /* No animation on Switch circle indicator if user has reduced motion set */
-  .bcds-react-aria-Switch > .indicator::before {
+  /* No animation on Switch handle if user has reduced motion set */
+  .bcds-react-aria-Switch--Button
+    > .bcds-react-aria-Switch--Track
+    > .bcds-react-aria-Switch--Handle {
     transition: none;
   }
 }
 
 /* Selected */
-.bcds-react-aria-Switch[data-selected] > .indicator {
+.bcds-react-aria-Switch--Button[data-selected]
+  > .bcds-react-aria-Switch--Track {
   background-color: var(--surface-color-primary-default);
-}
-
-.bcds-react-aria-Switch[data-selected] > .indicator::before {
-  transform: translateX(100%);
-  border: var(--layout-border-width-medium) solid
-    var(--surface-color-primary-default);
+  > .bcds-react-aria-Switch--Handle {
+    transform: translateX(100%);
+    border: var(--layout-border-width-medium) solid
+      var(--surface-color-primary-default);
+  }
 }
 
 /* Hover */
-.bcds-react-aria-Switch[data-hovered] {
+.bcds-react-aria-Switch--Button[data-hovered] {
   cursor: pointer;
-}
-
-.bcds-react-aria-Switch[data-hovered][data-selected] > .indicator {
-  background-color: var(--surface-color-primary-hover);
-}
-
-.bcds-react-aria-Switch[data-hovered] > .indicator::before {
-  border: var(--layout-border-width-medium) solid
-    var(--surface-color-border-dark);
-}
-
-.bcds-react-aria-Switch[data-hovered][data-selected] > .indicator::before {
-  border: var(--layout-border-width-medium) solid
-    var(--surface-color-primary-hover);
+  .bcds-react-aria-Switch--Handle {
+    border: var(--layout-border-width-medium) solid
+      var(--surface-color-border-dark);
+  }
 }
 
 /* Focused */
-.bcds-react-aria-Switch[data-focus-visible] > .indicator {
+.bcds-react-aria-Switch--Button[data-focus-visible]
+  > .bcds-react-aria-Switch--Track {
   outline: solid var(--layout-border-width-medium)
     var(--surface-color-border-active);
   outline-offset: var(--layout-margin-hair);
 }
 
+/* Read only */
+.bcds-react-aria-Switch--Button[data-readonly] {
+  cursor: not-allowed;
+}
+
 /* Disabled */
-.bcds-react-aria-Switch[data-disabled] {
+.bcds-react-aria-Switch--Button[data-disabled] {
   color: var(--typography-color-disabled);
   cursor: not-allowed;
+  > .bcds-react-aria-Switch--Track {
+    background-color: var(--surface-color-primary-disabled);
+  }
+  > .bcds-react-aria-Switch--Handle {
+    background-color: var(--theme-gray-10);
+    border: var(--layout-border-width-medium) solid
+      var(--surface-color-border-default);
+  }
 }
 
-.bcds-react-aria-Switch[data-disabled] > .indicator {
-  background-color: var(--surface-color-primary-disabled);
-}
+/* Compound states */
 
-.bcds-react-aria-Switch[data-disabled] > .indicator::before {
-  background-color: var(--theme-gray-10);
-  border: var(--layout-border-width-medium) solid
-    var(--surface-color-border-default);
-}
-
-/* Read only */
-.bcds-react-aria-Switch[data-readonly] {
-  cursor: not-allowed;
+.bcds-react-aria-Switch--Button[data-hovered][data-selected] {
+  .bcds-react-aria-Switch--Track {
+    background-color: var(--surface-color-primary-hover);
+  }
+  .bcds-react-aria-Switch--Handle {
+    border: var(--layout-border-width-medium) solid
+      var(--surface-color-primary-hover);
+  }
 }

--- a/packages/react-components/src/components/Switch/Switch.css
+++ b/packages/react-components/src/components/Switch/Switch.css
@@ -11,9 +11,8 @@
 /* Button */
 .bcds-react-aria-Switch--Button {
   display: flex;
-  flex-direction: row;
+  flex-flow: row wrap;
   align-items: center;
-  flex-wrap: wrap;
   gap: var(--layout-margin-small);
 }
 
@@ -75,17 +74,6 @@
   }
 }
 
-/* Selected */
-.bcds-react-aria-Switch--Button[data-selected]
-  > .bcds-react-aria-Switch--Track {
-  background-color: var(--surface-color-primary-default);
-  > .bcds-react-aria-Switch--Handle {
-    transform: translateX(100%);
-    border: var(--layout-border-width-medium) solid
-      var(--surface-color-primary-default);
-  }
-}
-
 /* Hover */
 .bcds-react-aria-Switch--Button[data-hovered] {
   cursor: pointer;
@@ -119,6 +107,17 @@
     background-color: var(--theme-gray-10);
     border: var(--layout-border-width-medium) solid
       var(--surface-color-border-default);
+  }
+}
+
+/* Selected */
+.bcds-react-aria-Switch--Button[data-selected]
+  > .bcds-react-aria-Switch--Track {
+  background-color: var(--surface-color-primary-default);
+  > .bcds-react-aria-Switch--Handle {
+    transform: translateX(100%);
+    border: var(--layout-border-width-medium) solid
+      var(--surface-color-primary-default);
   }
 }
 

--- a/packages/react-components/src/components/Switch/Switch.tsx
+++ b/packages/react-components/src/components/Switch/Switch.tsx
@@ -1,25 +1,65 @@
 import {
-  Switch as ReactAriaSwitch,
-  SwitchProps as ReactAriaSwitchProps,
+  SwitchButton as ReactAriaSwitchButton,
+  SwitchField as ReactAriaSwitchField,
+  SwitchFieldProps as ReactAriaSwitchFieldProps,
+  FieldError,
+  ValidationResult,
+  Text,
 } from "react-aria-components";
 
 import "./Switch.css";
+import SvgExclamationIcon from "../Icons/SvgExclamationIcon";
 
-export interface SwitchProps extends ReactAriaSwitchProps {
+export interface SwitchProps extends ReactAriaSwitchFieldProps {
   /* Label positioning relative to switch */
   labelPosition?: "left" | "right";
+  /* Sets optional description text below switch label */
+  description?: string;
+  /* Used for data validation and error handling */
+  errorMessage?: string | ((validation: ValidationResult) => string);
 }
 
 export default function Switch({
   labelPosition = "right",
+  description,
+  errorMessage,
   children,
   ...props
 }: SwitchProps) {
   return (
-    <ReactAriaSwitch className={`bcds-react-aria-Switch`} {...props}>
-      {labelPosition === "left" && <>{children}</>}
-      <div className="indicator" />
-      {labelPosition === "right" && <>{children}</>}
-    </ReactAriaSwitch>
+    <ReactAriaSwitchField className="bcds-react-aria-Switch" {...props}>
+      <ReactAriaSwitchButton className="bcds-react-aria-Switch--Button">
+        {({ isSelected, isDisabled }) => (
+          <>
+            {labelPosition === "left" && <>{children}</>}
+            <div className="bcds-react-aria-Switch--Track indicator">
+              <div
+                data-disabled={isDisabled || undefined}
+                className={
+                  isSelected
+                    ? "bcds-react-aria-Switch--Handle"
+                    : "bcds-react-aria-Switch--Handle indicator"
+                }
+              />
+            </div>
+            {labelPosition === "right" && <>{children}</>}
+          </>
+        )}
+      </ReactAriaSwitchButton>
+      {description && (
+        <Text
+          className="bcds-react-aria-Switch--Description"
+          slot="description"
+        >
+          {description}
+        </Text>
+      )}
+      <FieldError className="bcds-react-aria-Switch--Error">
+        <>
+          <SvgExclamationIcon />
+          {errorMessage}
+        </>
+      </FieldError>
+    </ReactAriaSwitchField>
   );
 }

--- a/packages/react-components/src/stories/Checkbox.stories.tsx
+++ b/packages/react-components/src/stories/Checkbox.stories.tsx
@@ -51,6 +51,11 @@ const meta = {
       description:
         "For a controlled component, whether the checkbox is selected",
     },
+    errorMessage: {
+      control: "text",
+      description:
+        "Message displayed when `isInvalid` prop is passed (usually populated dynamically)",
+    },
   },
 } satisfies Meta<typeof Checkbox>;
 

--- a/packages/react-components/src/stories/Switch.mdx
+++ b/packages/react-components/src/stories/Switch.mdx
@@ -69,6 +69,10 @@ Pass a text label to the `children` slot. This text will render as a `<label>`, 
 
 If you do not provide a visible label, you must use the `aria-label` or `aria-labelledby` props to label the switch for assistive technologies.
 
+#### Description
+
+You can also provide additional helper text via the `description` slot. The description is displayed below the switch.
+
 #### Label position
 
 By default, the text label renders to the right of the switch. Use the `labelPosition` prop to move the label to the left:

--- a/packages/react-components/src/stories/Switch.stories.tsx
+++ b/packages/react-components/src/stories/Switch.stories.tsx
@@ -14,6 +14,10 @@ const meta = {
       control: { type: "object" },
       description: "Used to set label text",
     },
+    description: {
+      control: { type: "text" },
+      description: "Optional description text below label",
+    },
     labelPosition: {
       options: ["left", "right"],
       control: { type: "radio" },
@@ -35,6 +39,11 @@ const meta = {
       control: "boolean",
       description: "Sets the switch to 'on' by default",
     },
+    errorMessage: {
+      control: "text",
+      description:
+        "Message displayed when `isInvalid` prop is passed (usually populated dynamically)",
+    },
   },
 } satisfies Meta<typeof Switch>;
 
@@ -45,6 +54,7 @@ export const SwitchTemplate: Story = {
   args: {
     children: "Label text",
     labelPosition: "right",
+    description: "The description field is optional.",
   },
   render: ({ ...args }: SwitchProps) => <Switch {...args} />,
 };


### PR DESCRIPTION
This PR closes #722. It refactors the Switch component to adopt the new API shipped in `react-aria-components` v1.18.0. Switch now uses the `SwitchField` and `SwitchButton` subcomponents internally. Switch now supports additional description and error message fields, displayed below the switch and label. This change is non-breaking. This PR also includes a refactor of Switch's CSS to conform to stylelint's `no-descending-specificity` rule (see #841.)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>