### PR TITLE
[DS-21] Calendar: add support for multiple selections

### DIFF
--- a/packages/react-components/src/components/Calendar/Calendar.tsx
+++ b/packages/react-components/src/components/Calendar/Calendar.tsx
@@ -6,6 +6,7 @@ import {
   DateValue,
 } from "react-aria-components";
 
+import type { CalendarSelectionMode } from "react-aria-components/Calendar";
 import { useDateFormatter } from "react-aria";
 
 import "./Calendar.css";
@@ -15,12 +16,13 @@ import Heading from "../Heading";
 import SvgChevronLeftIcon from "../Icons/SvgChevronLeftIcon";
 import SvgChevronRightIcon from "../Icons/SvgChevronRightIcon";
 
-export type { DateValue };
+export type { DateValue, CalendarSelectionMode };
 
 export default function Calendar({
   visibleDuration = { months: 1 },
+  selectionMode = "single",
   ...props
-}: CalendarProps<DateValue>) {
+}: CalendarProps<DateValue, CalendarSelectionMode>) {
   const monthFormatter = useDateFormatter({
     month: "long",
     year: "numeric",
@@ -29,6 +31,7 @@ export default function Calendar({
   return (
     <ReactAriaCalendar
       className="bcds-react-aria-Calendar"
+      selectionMode={selectionMode}
       visibleDuration={visibleDuration}
       {...props}
     >

--- a/packages/react-components/src/components/Calendar/index.ts
+++ b/packages/react-components/src/components/Calendar/index.ts
@@ -1,3 +1,3 @@
 export { default } from "./Calendar";
-export type { DateValue } from "./Calendar";
+export type { DateValue, CalendarSelectionMode } from "./Calendar";
 export type { CalendarProps } from "react-aria-components";

--- a/packages/react-components/src/stories/Calendar.mdx
+++ b/packages/react-components/src/stories/Calendar.mdx
@@ -23,8 +23,8 @@ import {
 # Calendar
 
 <Subtitle>
-  A calendar displays a list of dates in a grid and enables the user to select a
-  single date.
+  A calendar displays a list of dates in a grid and enables the user to select
+  one or more dates.
 </Subtitle>
 
 <InlineAlert
@@ -102,6 +102,12 @@ The `pageBehavior` prop controls how pagination works. By default, it is set to 
 Set `pageBehavior` to `single` to paginate by one unit of `visibleDuration` (e.g. 1 month) instead:
 
 <Canvas of={CalendarStories.PageBehavior} />
+
+### Selection modes
+
+By default, a calendar accepts a single selection. Set `selectionMode` to `multiple` to allow the user to select multiple dates:
+
+<Canvas of={CalendarStories.MultipleSelection} />
 
 ### Constraining values
 

--- a/packages/react-components/src/stories/Calendar.stories.tsx
+++ b/packages/react-components/src/stories/Calendar.stories.tsx
@@ -8,7 +8,11 @@ import {
 import { useLocale } from "react-aria-components";
 
 import { Calendar } from "../components";
-import { CalendarProps, DateValue } from "../components/Calendar";
+import {
+  CalendarProps,
+  DateValue,
+  CalendarSelectionMode,
+} from "../components/Calendar";
 
 const meta = {
   title: "Inputs and controls/Calendar",
@@ -34,6 +38,14 @@ const meta = {
       description: "Controls the behavior of pagination",
       table: {
         defaultValue: { summary: "visible" },
+      },
+    },
+    selectionMode: {
+      control: { type: "radio" },
+      options: ["single", "multiple"],
+      description: "How many options can be selected",
+      table: {
+        defaultValue: { summary: "single" },
       },
     },
     value: {
@@ -93,7 +105,9 @@ export const CalendarTemplate: Story = {
     firstDayOfWeek: "sun",
     isDisabled: false,
   },
-  render: ({ ...args }: CalendarProps<DateValue>) => <Calendar {...args} />,
+  render: ({ ...args }: CalendarProps<DateValue, CalendarSelectionMode>) => (
+    <Calendar {...args} />
+  ),
 };
 
 export const ConstrainedRange: Story = {
@@ -111,6 +125,13 @@ export const DefaultValue: Story = {
   args: {
     ...CalendarTemplate.args,
     defaultValue: today(getLocalTimeZone()),
+  },
+};
+
+export const MultipleSelection: Story = {
+  args: {
+    defaultValue: today(getLocalTimeZone()),
+    selectionMode: "multiple",
   },
 };
 


### PR DESCRIPTION
This PR closes #723. It extends the Calendar component to properly implement the multi-select support that shipped in `react-aria-components` v1.18.0. Setting the `selectionMode` prop to `multiple` (default is `single`)  will allow a user to select multiple dates in a calendar. Calendar now also exports the `CalendarSelectionMode` type. There is no visual change to the component, and this change is non-breaking. 



---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>