### PR TITLE
Use import.meta.dirname instead of __dirname in Vite config

### DIFF
--- a/packages/react-components/vite.config.ts
+++ b/packages/react-components/vite.config.ts
@@ -4,19 +4,15 @@ import react from "@vitejs/plugin-react";
 import path from "path";
 
 // https://vitejs.dev/config/
-import { fileURLToPath } from "node:url";
 import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
 import { playwright } from "@vitest/browser-playwright";
-const dirname =
-  typeof __dirname !== "undefined"
-    ? __dirname
-    : path.dirname(fileURLToPath(import.meta.url));
+const dirname = import.meta.dirname;
 
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(dirname, "./src"),
     },
   },
   plugins: [react()],


### PR DESCRIPTION
Currently when starting the Vite dev server in the React components library, it will throw this warning:

```sh
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - `__dirname` (vite.config.ts:11:10). Use `import.meta.dirname` instead
Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning.
```

This PR updates the Vite config to use `import.meta.dirname` instead of the [native Node.js `__dirname`](https://nodejs.org/docs/latest/api/modules.html#__dirname).