### PR TITLE
Add system prompt instructions to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Additional information and documentation:
 - [Figma library](https://www2.gov.bc.ca/gov/content?id=8E36BE1D10E04A17B0CD4D913FA7AC43#designers)
 - [Component docs](https://www2.gov.bc.ca/gov/content?id=8E36BE1D10E04A17B0CD4D913FA7AC43)
 
+### Using these libraries with LLMs
+
+Each library ships an `AGENTS.md` file to help AI agents make effective use of the B.C. Design System.
+
+Add the B.C. Design System boilerplate from [AGENTS.example.md](https://github.com/bcgov/design-system/blob/main/AGENTS.example.md) to an `AGENTS.md` file at the root of your project. This directs agents to load the package-specific instructions for each library.
+
 ## Contact
 
 The B.C. Design System is maintained by the Everyday Life Events Common Capabilities & AI Platforms branch at Connected Services BC, part of the Ministry of Citizens' Services. To get in touch:

--- a/packages/design-tokens/dist/README.md
+++ b/packages/design-tokens/dist/README.md
@@ -12,6 +12,14 @@ To use, install this package (`npm i @bcgov/design-tokens`) and import the desig
 
 This package includes tokens in JavaScript (ECMAScript Module and CommonJS), CSS and SCSS formats.
 
+### Using this library with LLMs
+
+Instructions for AI agents are shipped with this library (`/node_modules/@bcgov/design-tokens/AGENTS.md`).
+
+Add the B.C. Design System boilerplate from [AGENTS.example.md](https://github.com/bcgov/design-system/blob/main/AGENTS.example.md) to an `AGENTS.md` file at the root of your project. This directs agents to load the library-specific instructions.
+
+Run `/context` to confirm that your agent has loaded the instructions into its context window.
+
 ### JavaScript (ECMAScript Module)
 
 > **Try this first!** Using JavaScript variables can give you a better developer experience with autocomplete.

--- a/packages/react-components/README.md
+++ b/packages/react-components/README.md
@@ -17,6 +17,14 @@ If you have questions, you can:
 
 `npm install @bcgov/design-system-react-components`
 
+### Using this library with LLMs
+
+Instructions for AI agents are shipped with this library (`/node_modules/@bcgov/design-system-react-components/AGENTS.md`).
+
+Add the B.C. Design System boilerplate from [AGENTS.example.md](https://github.com/bcgov/design-system/blob/main/AGENTS.example.md) to an `AGENTS.md` file at the root of your project. This directs agents to load the library-specific instructions.
+
+Run `/context` to confirm that your agent has loaded the instructions into its context window.
+
 ### BC Sans font dependency
 
 This package installs [@bcgov/bc-sans](https://www.npmjs.com/package/@bcgov/bc-sans) as a peer dependency. You must import the font-face declarations from @bcgov/bc-sans and ensure the font is reachable for your end user. The React components require that the `BC Sans` font-face is available to display correctly. The components do not ship their own copies of the font to minimize your bundle size.


### PR DESCRIPTION
This PR modifies the README for the `bcgov/design-system` repo and the `@bcgov/design-tokens` / `@bcgov/design-system-react-components` libraries to add basic instructions on how to utilize the system prompts for LLMs added in #869.